### PR TITLE
Refactor Layout to Xilems/Flutters BoxConstraints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
+name = "castaway"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a17ed5635fc8536268e5d4de1e22e81ac34419e5f052d4d51f4e01dcc263fcc"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +115,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -269,12 +291,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
-name = "grid"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d196ffc1627db18a531359249b2bf8416178d84b729f3cebeb278f285fb9b58c"
-
-[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -316,6 +332,16 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "kurbo"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1618d4ebd923e97d67e7cd363d80aef35fe961005cbbbb3d2dad8bdd1bc63440"
+dependencies = [
+ "arrayvec",
+ "smallvec",
+]
 
 [[package]]
 name = "lazy_static"
@@ -389,15 +415,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -534,12 +551,13 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5659e52e4ba6e07b2dad9f1158f578ef84a73762625ddb51536019f34d180eb"
+checksum = "154b85ef15a5d1719bcaa193c3c81fe645cd120c156874cd660fe49fd21d1373"
 dependencies = [
  "bitflags 2.4.2",
  "cassowary",
+ "compact_str",
  "crossterm",
  "indoc",
  "itertools",
@@ -571,6 +589,12 @@ name = "rustversion"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
+
+[[package]]
+name = "ryu"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "scopeguard"
@@ -647,15 +671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "slotmap"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,19 +697,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum"
-version = "0.25.0"
+name = "static_assertions"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strum"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723b93e8addf9aa965ebe2d11da6d7540fa2283fcea14b3371ff055f7ba13f5f"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -723,18 +744,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "taffy"
-version = "0.3.11"
-source = "git+https://github.com/Philipp-M/taffy.git?branch=null-node#f843625a6405e9712a1b35feac52a3d598184245"
-dependencies = [
- "arrayvec",
- "grid",
- "num-traits",
- "serde",
- "slotmap",
 ]
 
 [[package]]
@@ -905,9 +914,9 @@ dependencies = [
  "futures",
  "futures-task",
  "futures-util",
+ "kurbo",
  "rand",
  "ratatui",
- "taffy",
  "tokio",
  "tracing",
  "tracing-appender",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 # xilem_core = { path = "../xilem/xilem/crates/xilem_core" }
 xilem_core = { git = "https://github.com/Philipp-M/xilem.git", branch = "personal" }
 crossterm = "0.27"
-taffy = { git = "https://github.com/Philipp-M/taffy.git", branch = "null-node" }
 futures-task = "0.3"
 futures-util = "0.3"
 tokio = { version = "1.35", features = ["full"] }
@@ -15,8 +14,9 @@ anyhow = "1.0"
 tracing = "0.1.40"
 tracing-appender = "0.2"
 tracing-subscriber = "0.3"
+kurbo = "0.10.4"
 # update this when a new release occurs
-ratatui = "0.25"
+ratatui = "0.26"
 bitflags = "2.4.2"
 unicode-segmentation = "1.10.1"
 unicode-width = "0.1.11"

--- a/examples/blocks.rs
+++ b/examples/blocks.rs
@@ -4,12 +4,11 @@ use anyhow::Result;
 use ratatui::style::{Color, Style};
 use trui::*;
 
-// TODO layouting is not really optimal yet (needs to be configurable, a good abstraction on top of taffy likely)
 fn main() -> Result<()> {
     let view = Arc::new(
         block(h_stack((
             v_stack((
-                block(("With".fg(Color::Yellow), " background").wrapped()).bg(Color::LightYellow),
+                // block(("With".fg(Color::Yellow), " background").wrapped()).bg(Color::LightYellow),
                 block("text inside block").with_borders(BorderKind::Straight),
             )),
             v_stack((

--- a/examples/wrapped_text.rs
+++ b/examples/wrapped_text.rs
@@ -1,14 +1,16 @@
 use anyhow::Result;
-use ratatui::style::Color;
-use trui::*;
+// use ratatui::style::Color;
+// use trui::*;
 
+// TODO this currently doesn't work anymore
 fn main() -> Result<()> {
-    App::new((), |()| {
-        h_stack((
-            block(("Different ".fg(Color::Red), "Colors that are wrapped: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.".fg(Color::Blue)).wrapped()),
-            // TODO proper wrapping with new lines etc.
-            block("This should be wrapped very soon:\n\n Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.".wrapped()),
-        ))
-    })
-    .run()
+    // App::new((), |()| {
+    //     h_stack((
+    //         block(("Different ".fg(Color::Red), "Colors that are wrapped: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.".fg(Color::Blue)).wrapped()),
+    //         // TODO proper wrapping with new lines etc.
+    //         block("This should be wrapped very soon:\n\n Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.".wrapped()),
+    //     ))
+    // })
+    // .run()
+    Ok(())
 }

--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,0 +1,222 @@
+use crate::widget::BoxConstraints;
+pub use kurbo::{Point, Rect, Size, Vec2};
+use std::ops::Range;
+
+/// An axis in visual space.
+///
+/// Most often used by widgets to describe
+/// the direction in which they grow as their number of children increases.
+/// Has some methods for manipulating geometry with respect to the axis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Axis {
+    /// The x axis
+    Horizontal,
+    /// The y axis
+    Vertical,
+}
+
+pub fn to_ratatui_rect(rect: Rect) -> ratatui::layout::Rect {
+    ratatui::layout::Rect {
+        x: rect.x0.round().clamp(0.0, u16::MAX as f64) as u16,
+        y: rect.y0.round().clamp(0.0, u16::MAX as f64) as u16,
+        width: rect.x1.round().clamp(0.0, u16::MAX as f64) as u16,
+        height: rect.y1.round().clamp(0.0, u16::MAX as f64) as u16,
+    }
+}
+
+impl Axis {
+    /// Returns the orthogonal axis.
+    ///
+    /// `v.cross().cross()` is always identical to `v`.
+    pub fn cross(self) -> Self {
+        match self {
+            Axis::Horizontal => Axis::Vertical,
+            Axis::Vertical => Axis::Horizontal,
+        }
+    }
+
+    /// Returns the scalar of the value on this axis.
+    pub fn major<T: Dim2>(self, value: T) -> T::Scalar {
+        match self {
+            Axis::Horizontal => value.x(),
+            Axis::Vertical => value.y(),
+        }
+    }
+
+    /// Returns the scalar of the value on the orthogonal axis.
+    pub fn minor<T: Dim2>(self, value: T) -> T::Scalar {
+        self.cross().major(value)
+    }
+
+    /// Sets the scalar of the value on this axis and returns the new value.
+    pub fn with_major<T: Dim2>(self, value: T, major: T::Scalar) -> T {
+        match self {
+            Axis::Horizontal => T::new(major, value.y()),
+            Axis::Vertical => T::new(value.x(), major),
+        }
+    }
+
+    /// Sets the scalar of the value on the orthogonal axis and returns the new value.
+    pub fn with_minor<T: Dim2>(self, value: T, minor: T::Scalar) -> T {
+        self.cross().with_major(value, minor)
+    }
+
+    /// Updates the scalar of value on this axis.
+    pub fn set_major<T: Dim2>(self, value: &mut T, major: T::Scalar) {
+        *value = match self {
+            Axis::Horizontal => T::new(major, value.y()),
+            Axis::Vertical => T::new(value.x(), major),
+        };
+    }
+
+    /// Updates the scalar of value on the orthogonal axis.
+    pub fn set_minor<T: Dim2>(self, value: &mut T, major: T::Scalar) {
+        self.cross().set_major(value, major)
+    }
+
+    /// Maps the scalar of the value on this axis.
+    pub fn map_major<T: Dim2 + Copy, F: FnOnce(T::Scalar) -> T::Scalar>(
+        self,
+        value: T,
+        map: F,
+    ) -> T {
+        match self {
+            Axis::Horizontal => T::new(map(value.x()), value.y()),
+            Axis::Vertical => T::new(value.x(), map(value.y())),
+        }
+    }
+
+    /// Maps the scalar of the value on the orthogonal axis.
+    pub fn map_minor<T: Dim2 + Copy, F: FnOnce(T::Scalar) -> T::Scalar>(
+        self,
+        value: T,
+        map: F,
+    ) -> T {
+        self.cross().map_major(value, map)
+    }
+
+    /// Returns a value created from the given scalars.
+    pub fn pack<T: Dim2>(self, major: T::Scalar, minor: T::Scalar) -> T {
+        match self {
+            Axis::Horizontal => T::new(major, minor),
+            Axis::Vertical => T::new(minor, major),
+        }
+    }
+}
+
+/// Types implementing this Trait can be used with [`Axis`] to create axis independent algorithms.
+///
+/// Types which implement this trait must consist of to identical sets of information, which can be
+/// represented as the associated type Scalar, and no additional data.
+pub trait Dim2: Copy {
+    /// Scalar represents the value of each Axis of this type.
+    /// The value does not have to be a single number.
+    type Scalar;
+
+    /// Constructs this type from an X-Axis and a Y-Axis.
+    ///
+    /// Any value `v` of which the type implements Dim2 must be equal to `Dim2::new(v.x(), v.y()))`
+    fn new(x: Self::Scalar, y: Self::Scalar) -> Self;
+
+    /// Returns the X-Axis of this type.
+    fn x(self) -> Self::Scalar;
+
+    /// Returns the Y-Axis of this type.
+    fn y(self) -> Self::Scalar;
+}
+
+impl Dim2 for Point {
+    type Scalar = f64;
+
+    fn new(x: Self::Scalar, y: Self::Scalar) -> Self {
+        Point::new(x, y)
+    }
+
+    fn x(self) -> Self::Scalar {
+        self.x
+    }
+
+    fn y(self) -> Self::Scalar {
+        self.y
+    }
+}
+
+impl Dim2 for Vec2 {
+    type Scalar = f64;
+
+    fn new(x: Self::Scalar, y: Self::Scalar) -> Self {
+        Vec2::new(x, y)
+    }
+
+    fn x(self) -> Self::Scalar {
+        self.x
+    }
+
+    fn y(self) -> Self::Scalar {
+        self.y
+    }
+}
+
+impl Dim2 for Size {
+    type Scalar = f64;
+
+    fn new(x: Self::Scalar, y: Self::Scalar) -> Self {
+        Size::new(x, y)
+    }
+
+    fn x(self) -> Self::Scalar {
+        self.width
+    }
+
+    fn y(self) -> Self::Scalar {
+        self.height
+    }
+}
+
+/// A Span is a range of values on a given [`Axis`].
+///
+/// Its main use is to define [`Dim2`] for [`Rect`]. This in turn allows us to use Axis together
+/// with Rect.
+pub struct Span {
+    pub low: f64,
+    pub high: f64,
+}
+
+impl Dim2 for Rect {
+    type Scalar = Span;
+
+    fn new(x: Self::Scalar, y: Self::Scalar) -> Self {
+        Rect::new(x.low, y.low, x.high, y.high)
+    }
+
+    fn x(self) -> Self::Scalar {
+        Span {
+            low: self.x0,
+            high: self.x1,
+        }
+    }
+
+    fn y(self) -> Self::Scalar {
+        Span {
+            low: self.y0,
+            high: self.y1,
+        }
+    }
+}
+
+impl Dim2 for BoxConstraints {
+    //TODO: Range has an Exclusive upper Bound, this is not consistent with BoxConstrains.
+    type Scalar = Range<f64>;
+
+    fn new(x: Self::Scalar, y: Self::Scalar) -> Self {
+        BoxConstraints::new(Size::new(x.start, y.start), Size::new(x.end, y.end))
+    }
+
+    fn x(self) -> Self::Scalar {
+        self.min().width..self.max().width
+    }
+
+    fn y(self) -> Self::Scalar {
+        self.min().height..self.max().height
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod app;
+pub mod geometry;
 mod view;
 mod widget;
 
@@ -6,4 +7,4 @@ mod widget;
 pub use app::App;
 pub use ratatui::style::{Color, Modifier, Style};
 pub use view::*;
-pub use widget::{CatchMouseButton, Point, Rect};
+pub use widget::CatchMouseButton;

--- a/src/view/linear_layout.rs
+++ b/src/view/linear_layout.rs
@@ -1,12 +1,15 @@
 use super::{Cx, View, ViewMarker, ViewSequence};
-use crate::widget::{self, ChangeFlags};
+use crate::{
+    geometry::Axis,
+    widget::{self, ChangeFlags},
+};
 use std::{any::Any, marker::PhantomData};
-use taffy::style::FlexDirection;
 use xilem_core::{Id, VecSplice};
 
 pub struct LinearLayout<T, A, VT> {
     children: VT,
-    direction: FlexDirection,
+    axis: Axis,
+    spacing: f64,
     phantom: PhantomData<fn() -> (T, A)>,
 }
 
@@ -20,7 +23,7 @@ impl<T, A, VT: ViewSequence<T, A>> View<T, A> for LinearLayout<T, A, VT> {
     fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
         let mut elements = vec![];
         let (id, state) = cx.with_new_id(|cx| self.children.build(cx, &mut elements));
-        let column = widget::LinearLayout::new(elements, self.direction);
+        let column = widget::LinearLayout::new(elements, self.spacing, self.axis);
         (id, state, column)
     }
 
@@ -55,7 +58,8 @@ impl<T, A, VT: ViewSequence<T, A>> View<T, A> for LinearLayout<T, A, VT> {
 pub fn h_stack<T, A, VT: ViewSequence<T, A>>(children: VT) -> LinearLayout<T, A, VT> {
     LinearLayout {
         children,
-        direction: FlexDirection::Row,
+        spacing: 0.0,
+        axis: Axis::Horizontal,
         phantom: PhantomData,
     }
 }
@@ -63,7 +67,8 @@ pub fn h_stack<T, A, VT: ViewSequence<T, A>>(children: VT) -> LinearLayout<T, A,
 pub fn v_stack<T, A, VT: ViewSequence<T, A>>(children: VT) -> LinearLayout<T, A, VT> {
     LinearLayout {
         children,
-        direction: FlexDirection::Column,
+        spacing: 0.0,
+        axis: Axis::Vertical,
         phantom: PhantomData,
     }
 }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,16 +1,17 @@
 mod block;
+mod box_constraints;
 mod core;
 mod events;
 mod linear_layout;
 mod text;
 
 pub use self::core::{
-    AnyWidget, ChangeFlags, CxState, Event, EventCx, LayoutCx, Message, PaintCx, Pod, Point,
+    AnyWidget, ChangeFlags, CxState, Event, EventCx, LayoutCx, LifeCycleCx, Message, PaintCx, Pod,
     StyleableWidget, Widget,
 };
 pub(crate) use self::core::{PodFlags, WidgetState};
 pub(crate) use block::Block;
+pub use box_constraints::BoxConstraints;
 pub use events::*;
 pub(crate) use linear_layout::LinearLayout;
-pub use ratatui::layout::Rect;
 pub(crate) use text::*;

--- a/src/widget/box_constraints.rs
+++ b/src/widget/box_constraints.rs
@@ -1,0 +1,428 @@
+// Copyright 2019 The Druid Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The fundamental druid types.
+
+use crate::geometry::Axis;
+use kurbo::Size;
+
+/// Constraints for layout.
+///
+/// The layout strategy for druid is strongly inspired by Flutter,
+/// and this struct is similar to the [Flutter BoxConstraints] class.
+///
+/// At the moment, it represents simply a minimum and maximum size.
+/// A widget's [`layout`] method should choose an:: appropriate size that
+/// meets these constraints.
+///
+/// Further, a container widget should compute appropriate constraints
+/// for each of its child widgets, and pass those down when recursing.
+///
+/// The constraints are always [rounded away from zero] to integers
+/// to enable pixel perfect layout.
+///
+/// [`layout`]: trait.Widget.html#tymethod.layout
+/// [Flutter BoxConstraints]: https://api.flutter.dev/flutter/rendering/BoxConstraints-class.html
+/// [rounded away from zero]: struct.Size.html#method.expand
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BoxConstraints {
+    min: Size,
+    max: Size,
+}
+
+impl BoxConstraints {
+    /// An unbounded box constraints object.
+    ///
+    /// Can be satisfied by any nonnegative size.
+    pub const UNBOUNDED: BoxConstraints = BoxConstraints {
+        min: Size::ZERO,
+        max: Size::new(f64::INFINITY, f64::INFINITY),
+    };
+
+    /// Create a new box constraints object.
+    ///
+    /// Create constraints based on minimum and maximum size.
+    ///
+    /// The given sizes are also [rounded away from zero],
+    /// so that the layout is aligned to integers.
+    ///
+    /// [rounded away from zero]: struct.Size.html#method.expand
+    pub fn new(min: Size, max: Size) -> BoxConstraints {
+        BoxConstraints {
+            min: min.expand(),
+            max: max.expand(),
+        }
+    }
+
+    /// Create a "tight" box constraints object.
+    ///
+    /// A "tight" constraint can only be satisfied by a single size.
+    ///
+    /// The given size is also [rounded away from zero],
+    /// so that the layout is aligned to integers.
+    ///
+    /// [rounded away from zero]: struct.Size.html#method.expand
+    pub fn tight(size: Size) -> BoxConstraints {
+        let size = size.expand();
+        BoxConstraints {
+            min: size,
+            max: size,
+        }
+    }
+
+    /// Create a "loose" version of the constraints.
+    ///
+    /// Make a version with zero minimum size, but the same maximum size.
+    pub fn loosen(&self) -> BoxConstraints {
+        BoxConstraints {
+            min: Size::ZERO,
+            max: self.max,
+        }
+    }
+
+    /// Clamp a given size so that it fits within the constraints.
+    ///
+    /// The given size is also [rounded away from zero],
+    /// so that the layout is aligned to integers.
+    ///
+    /// [rounded away from zero]: struct.Size.html#method.expand
+    pub fn constrain(&self, size: impl Into<Size>) -> Size {
+        size.into().expand().clamp(self.min, self.max)
+    }
+
+    /// Returns the max size of these constraints.
+    pub fn max(&self) -> Size {
+        self.max
+    }
+
+    /// Returns the min size of these constraints.
+    pub fn min(&self) -> Size {
+        self.min
+    }
+
+    /// Whether there is an upper bound on the width.
+    pub fn is_width_bounded(&self) -> bool {
+        self.max.width.is_finite()
+    }
+
+    /// Whether there is an upper bound on the height.
+    pub fn is_height_bounded(&self) -> bool {
+        self.max.height.is_finite()
+    }
+
+    /// Check to see if these constraints are legit.
+    ///
+    /// Logs a warning if BoxConstraints are invalid.
+    pub fn debug_check(&self, name: &str) {
+        if !(0.0 <= self.min.width
+            && self.min.width <= self.max.width
+            && 0.0 <= self.min.height
+            && self.min.height <= self.max.height
+            && self.min.expand() == self.min
+            && self.max.expand() == self.max)
+        {
+            tracing::warn!("Bad BoxConstraints passed to {}:", name);
+            tracing::warn!("{:?}", self);
+        }
+
+        if self.min.width.is_infinite() {
+            tracing::warn!("Infinite minimum width constraint passed to {}:", name);
+        }
+
+        if self.min.height.is_infinite() {
+            tracing::warn!("Infinite minimum height constraint passed to {}:", name);
+        }
+    }
+
+    /// Shrink min and max constraints by size
+    ///
+    /// The given size is also [rounded away from zero],
+    /// so that the layout is aligned to integers.
+    ///
+    /// [rounded away from zero]: struct.Size.html#method.expand
+    pub fn shrink(&self, diff: impl Into<Size>) -> BoxConstraints {
+        let diff = diff.into().expand();
+        let min = Size::new(
+            (self.min().width - diff.width).max(0.),
+            (self.min().height - diff.height).max(0.),
+        );
+        let max = Size::new(
+            (self.max().width - diff.width).max(0.),
+            (self.max().height - diff.height).max(0.),
+        );
+
+        BoxConstraints::new(min, max)
+    }
+
+    /// Test whether these constraints contain the given `Size`.
+    pub fn contains(&self, size: impl Into<Size>) -> bool {
+        let size = size.into();
+        (self.min.width <= size.width && size.width <= self.max.width)
+            && (self.min.height <= size.height && size.height <= self.max.height)
+    }
+
+    /// Find the `Size` within these `BoxConstraint`s that minimises the difference between the
+    /// returned `Size`'s aspect ratio and `aspect_ratio`, where *aspect ratio* is defined as
+    /// `height / width`.
+    ///
+    /// If multiple `Size`s give the optimal `aspect_ratio`, then the one with the `width` nearest
+    /// the supplied width will be used. Specifically, if `width == 0.0` then the smallest possible
+    /// `Size` will be chosen, and likewise if `width == f64::INFINITY`, then the largest `Size`
+    /// will be chosen.
+    ///
+    /// Use this function when maintaining an aspect ratio is more important than minimizing the
+    /// distance between input and output size width and height.
+    pub fn constrain_aspect_ratio(&self, aspect_ratio: f64, width: f64) -> Size {
+        // Minimizing/maximizing based on aspect ratio seems complicated, but in reality everything
+        // is linear, so the amount of work to do is low.
+        let ideal_size = Size {
+            width,
+            height: width * aspect_ratio,
+        };
+
+        // It may be possible to remove these in the future if the invariant is checked elsewhere.
+        let aspect_ratio = aspect_ratio.abs();
+        let width = width.abs();
+
+        // Firstly check if we can simply return the exact requested
+        if self.contains(ideal_size) {
+            return ideal_size;
+        }
+
+        // Then we check if any `Size`s with our desired aspect ratio are inside the constraints.
+        // TODO this currently outputs garbage when things are < 0.
+        let min_w_min_h = self.min.height / self.min.width;
+        let max_w_min_h = self.min.height / self.max.width;
+        let min_w_max_h = self.max.height / self.min.width;
+        let max_w_max_h = self.max.height / self.max.width;
+
+        // When the aspect ratio line crosses the constraints, the closest point must be one of the
+        // two points where the aspect ratio enters/exits.
+
+        // When the aspect ratio line doesn't intersect the box of possible sizes, the closest
+        // point must be either (max width, min height) or (max height, min width). So all we have
+        // to do is check which one of these has the closest aspect ratio.
+
+        // Check each possible intersection (or not) of the aspect ratio line with the constraints
+        if aspect_ratio > min_w_max_h {
+            // outside max height min width
+            Size {
+                width: self.min.width,
+                height: self.max.height,
+            }
+        } else if aspect_ratio < max_w_min_h {
+            // outside min height max width
+            Size {
+                width: self.max.width,
+                height: self.min.height,
+            }
+        } else if aspect_ratio > min_w_min_h {
+            // hits the constraints on the min width line
+            if width < self.min.width {
+                // we take the point on the min width
+                Size {
+                    width: self.min.width,
+                    height: self.min.width * aspect_ratio,
+                }
+            } else if aspect_ratio < max_w_max_h {
+                // exits through max.width
+                Size {
+                    width: self.max.width,
+                    height: self.max.width * aspect_ratio,
+                }
+            } else {
+                // exits through max.height
+                Size {
+                    width: self.max.height * aspect_ratio.recip(),
+                    height: self.max.height,
+                }
+            }
+        } else {
+            // final case is where we hit constraints on the min height line
+            if width < self.min.width {
+                // take the point on the min height
+                Size {
+                    width: self.min.height * aspect_ratio.recip(),
+                    height: self.min.height,
+                }
+            } else if aspect_ratio > max_w_max_h {
+                // exit thru max height
+                Size {
+                    width: self.max.height * aspect_ratio.recip(),
+                    height: self.max.height,
+                }
+            } else {
+                // exit thru max width
+                Size {
+                    width: self.max.width,
+                    height: self.max.width * aspect_ratio,
+                }
+            }
+        }
+    }
+
+    /// Sets the max on a given axis to infinity.
+    pub fn unbound_max(&self, axis: Axis) -> Self {
+        match axis {
+            Axis::Horizontal => self.unbound_max_width(),
+            Axis::Vertical => self.unbound_max_height(),
+        }
+    }
+
+    /// Sets max width to infinity.
+    pub fn unbound_max_width(&self) -> Self {
+        let mut max = self.max();
+        max.width = f64::INFINITY;
+        BoxConstraints::new(self.min(), max)
+    }
+
+    /// Sets max height to infinity.
+    pub fn unbound_max_height(&self) -> Self {
+        let mut max = self.max();
+        max.height = f64::INFINITY;
+        BoxConstraints::new(self.min(), max)
+    }
+
+    /// Shrinks the max dimension on the given axis.
+    /// Does NOT shrink beyond min.
+    pub fn shrink_max_to(&self, axis: Axis, dim: f64) -> Self {
+        match axis {
+            Axis::Horizontal => self.shrink_max_width_to(dim),
+            Axis::Vertical => self.shrink_max_height_to(dim),
+        }
+    }
+
+    /// Shrinks the max width to dim.
+    /// Does NOT shrink beyond min width.
+    pub fn shrink_max_width_to(&self, dim: f64) -> Self {
+        let mut max = self.max();
+        max.width = f64::max(dim, self.min().width);
+        BoxConstraints::new(self.min(), max)
+    }
+
+    /// Shrinks the max height to dim.
+    /// Does NOT shrink beyond min height.
+    pub fn shrink_max_height_to(&self, dim: f64) -> Self {
+        let mut max = self.max();
+        max.height = f64::max(dim, self.min().height);
+        BoxConstraints::new(self.min(), max)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bc(min_width: f64, min_height: f64, max_width: f64, max_height: f64) -> BoxConstraints {
+        BoxConstraints::new(
+            Size::new(min_width, min_height),
+            Size::new(max_width, max_height),
+        )
+    }
+
+    #[test]
+    fn constrain_aspect_ratio() {
+        for (bc, aspect_ratio, width, output) in [
+            // The ideal size lies within the constraints
+            (bc(0.0, 0.0, 100.0, 100.0), 1.0, 50.0, Size::new(50.0, 50.0)),
+            (bc(0.0, 10.0, 90.0, 100.0), 1.0, 50.0, Size::new(50.0, 50.0)),
+            // The correct aspect ratio is available (but not width)
+            // min height
+            (
+                bc(10.0, 10.0, 100.0, 100.0),
+                1.0,
+                5.0,
+                Size::new(10.0, 10.0),
+            ),
+            (
+                bc(40.0, 90.0, 60.0, 100.0),
+                2.0,
+                30.0,
+                Size::new(45.0, 90.0),
+            ),
+            (
+                bc(10.0, 10.0, 100.0, 100.0),
+                0.5,
+                5.0,
+                Size::new(20.0, 10.0),
+            ),
+            // min width
+            (
+                bc(10.0, 10.0, 100.0, 100.0),
+                2.0,
+                5.0,
+                Size::new(10.0, 20.0),
+            ),
+            (
+                bc(90.0, 40.0, 100.0, 60.0),
+                0.5,
+                60.0,
+                Size::new(90.0, 45.0),
+            ),
+            (
+                bc(50.0, 0.0, 50.0, 100.0),
+                1.0,
+                100.0,
+                Size::new(50.0, 50.0),
+            ),
+            // max height
+            (
+                bc(10.0, 10.0, 100.0, 100.0),
+                2.0,
+                105.0,
+                Size::new(50.0, 100.0),
+            ),
+            (
+                bc(10.0, 10.0, 100.0, 100.0),
+                0.5,
+                105.0,
+                Size::new(100.0, 50.0),
+            ),
+            // The correct aspet ratio is not available
+            (
+                bc(20.0, 20.0, 40.0, 40.0),
+                10.0,
+                30.0,
+                Size::new(20.0, 40.0),
+            ),
+            (bc(20.0, 20.0, 40.0, 40.0), 0.1, 30.0, Size::new(40.0, 20.0)),
+            // non-finite
+            (
+                bc(50.0, 0.0, 50.0, f64::INFINITY),
+                1.0,
+                100.0,
+                Size::new(50.0, 50.0),
+            ),
+        ]
+        .iter()
+        {
+            assert_eq!(
+                bc.constrain_aspect_ratio(*aspect_ratio, *width),
+                *output,
+                "bc:{:?}, ar:{}, w:{}",
+                bc,
+                aspect_ratio,
+                width
+            );
+        }
+    }
+
+    #[test]
+    fn unbounded() {
+        assert!(!BoxConstraints::UNBOUNDED.is_width_bounded());
+        assert!(!BoxConstraints::UNBOUNDED.is_height_bounded());
+
+        assert_eq!(BoxConstraints::UNBOUNDED.min(), Size::ZERO);
+    }
+}

--- a/src/widget/box_constraints.rs
+++ b/src/widget/box_constraints.rs
@@ -14,8 +14,7 @@
 
 //! The fundamental druid types.
 
-use crate::geometry::Axis;
-use kurbo::Size;
+use crate::geometry::{Axis, Size};
 
 /// Constraints for layout.
 ///

--- a/src/widget/events.rs
+++ b/src/widget/events.rs
@@ -1,7 +1,7 @@
 use bitflags::bitflags;
 use std::marker::PhantomData;
 
-use crate::geometry::Point;
+use crate::geometry::{Point, Size};
 use crossterm::event::{MouseButton, MouseEventKind};
 use ratatui::style::Style;
 
@@ -99,7 +99,7 @@ impl<E: Widget> Widget for OnMouse<E> {
         self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> Size {
         self.element.layout(cx, bc)
     }
 
@@ -190,7 +190,7 @@ impl<E: Widget> Widget for OnClick<E> {
         self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> Size {
         self.element.layout(cx, bc)
     }
 
@@ -253,7 +253,7 @@ impl<E: Widget> Widget for OnHover<E> {
         self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> Size {
         self.element.layout(cx, bc)
     }
 
@@ -296,7 +296,7 @@ impl<E: Widget> Widget for OnHoverLost<E> {
         self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> Size {
         self.element.layout(cx, bc)
     }
 
@@ -342,7 +342,7 @@ impl<E: Widget + StyleableWidget> Widget for StyleOnHover<E> {
         self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> Size {
         self.element.layout(cx, bc)
     }
 
@@ -395,7 +395,7 @@ impl<E: Widget> Widget for StyleOnPressed<E> {
         self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> Size {
         self.element.layout(cx, bc)
     }
 

--- a/src/widget/events.rs
+++ b/src/widget/events.rs
@@ -1,14 +1,46 @@
 use bitflags::bitflags;
 use std::marker::PhantomData;
 
+use crate::geometry::Point;
 use crossterm::event::{MouseButton, MouseEventKind};
 use ratatui::style::Style;
-use taffy::tree::NodeId;
 
 use super::{
     core::{IdPath, PaintCx, StyleableWidget},
     ChangeFlags, Event, EventCx, LayoutCx, Message, Pod, Widget,
 };
+
+#[derive(Debug)]
+pub enum LifeCycle {
+    HotChanged(bool),
+    ViewContextChanged(ViewContext),
+    TreeUpdate,
+}
+
+#[derive(Debug)]
+pub struct ViewContext {
+    pub window_origin: Point,
+    // pub clip: Rect,
+    pub mouse_position: Option<Point>,
+}
+
+impl ViewContext {
+    pub fn translate_to(&self, new_origin: Point) -> ViewContext {
+        // TODO I think the clip calculation is buggy in xilem (width/height?)
+        // let clip = Rect {
+        //     x: self.clip.x - new_origin.x,
+        //     y: self.clip.y - new_origin.y,
+        //     width: self.clip.width,
+        //     height: self.clip.height,
+        // };
+        let translate = new_origin.to_vec2();
+        ViewContext {
+            window_origin: self.window_origin + translate,
+            // clip,
+            mouse_position: self.mouse_position.map(|p| p - translate),
+        }
+    }
+}
 
 #[derive(Debug)]
 /// A message representing a mouse event.
@@ -64,11 +96,11 @@ impl<E: Widget> OnMouse<E> {
 
 impl<E: Widget> Widget for OnMouse<E> {
     fn paint(&mut self, cx: &mut PaintCx) {
-        self.element.paint(cx, cx.rect());
+        self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, _prev: NodeId) -> NodeId {
-        self.element.layout(cx)
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+        self.element.layout(cx, bc)
     }
 
     fn event(&mut self, cx: &mut EventCx, event: &Event) {
@@ -122,6 +154,10 @@ impl<E: Widget> Widget for OnMouse<E> {
             _ => (),
         }
     }
+
+    fn lifecycle(&mut self, cx: &mut super::core::LifeCycleCx, event: &LifeCycle) {
+        self.element.lifecycle(cx, event);
+    }
 }
 
 impl<E: Widget + StyleableWidget> StyleableWidget for OnMouse<E> {
@@ -151,11 +187,11 @@ impl<E: Widget> OnClick<E> {
 
 impl<E: Widget> Widget for OnClick<E> {
     fn paint(&mut self, cx: &mut PaintCx) {
-        self.element.paint(cx, cx.rect());
+        self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, _prev: NodeId) -> NodeId {
-        self.element.layout(cx)
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+        self.element.layout(cx, bc)
     }
 
     fn event(&mut self, cx: &mut EventCx, event: &Event) {
@@ -180,6 +216,10 @@ impl<E: Widget> Widget for OnClick<E> {
             }
             cx.set_active(false);
         }
+    }
+
+    fn lifecycle(&mut self, cx: &mut super::core::LifeCycleCx, event: &LifeCycle) {
+        self.element.lifecycle(cx, event);
     }
 }
 
@@ -213,8 +253,8 @@ impl<E: Widget> Widget for OnHover<E> {
         self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, prev: NodeId) -> NodeId {
-        self.element.layout(cx, prev)
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+        self.element.layout(cx, bc)
     }
 
     fn event(&mut self, cx: &mut EventCx, event: &Event) {
@@ -228,6 +268,10 @@ impl<E: Widget> Widget for OnHover<E> {
                 self.is_hovering = false;
             }
         }
+    }
+
+    fn lifecycle(&mut self, cx: &mut super::core::LifeCycleCx, event: &LifeCycle) {
+        self.element.lifecycle(cx, event);
     }
 }
 
@@ -252,8 +296,8 @@ impl<E: Widget> Widget for OnHoverLost<E> {
         self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, prev: NodeId) -> NodeId {
-        self.element.layout(cx, prev)
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+        self.element.layout(cx, bc)
     }
 
     fn event(&mut self, cx: &mut EventCx, event: &Event) {
@@ -267,6 +311,10 @@ impl<E: Widget> Widget for OnHoverLost<E> {
                 cx.add_message(Message::new(self.id_path.clone(), ()));
             }
         }
+    }
+
+    fn lifecycle(&mut self, cx: &mut super::core::LifeCycleCx, event: &LifeCycle) {
+        self.element.lifecycle(cx, event);
     }
 }
 
@@ -294,8 +342,8 @@ impl<E: Widget + StyleableWidget> Widget for StyleOnHover<E> {
         self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, prev: NodeId) -> NodeId {
-        self.element.layout(cx, prev)
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+        self.element.layout(cx, bc)
     }
 
     fn event(&mut self, cx: &mut EventCx, event: &Event) {
@@ -307,6 +355,10 @@ impl<E: Widget + StyleableWidget> Widget for StyleOnHover<E> {
             cx.request_paint();
             self.is_hovering = false;
         }
+    }
+
+    fn lifecycle(&mut self, cx: &mut super::core::LifeCycleCx, event: &LifeCycle) {
+        self.element.lifecycle(cx, event);
     }
 }
 
@@ -340,11 +392,11 @@ impl<E: Widget> Widget for StyleOnPressed<E> {
         if cx.is_active() {
             cx.override_style = self.style.patch(cx.override_style);
         };
-        self.element.paint(cx, cx.rect());
+        self.element.paint(cx);
     }
 
-    fn layout(&mut self, cx: &mut LayoutCx, _prev: NodeId) -> NodeId {
-        self.element.layout(cx)
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &super::BoxConstraints) -> kurbo::Size {
+        self.element.layout(cx, bc)
     }
 
     fn event(&mut self, cx: &mut EventCx, event: &Event) {
@@ -368,6 +420,10 @@ impl<E: Widget> Widget for StyleOnPressed<E> {
             }
             _ => (),
         }
+    }
+
+    fn lifecycle(&mut self, cx: &mut super::core::LifeCycleCx, event: &LifeCycle) {
+        self.element.lifecycle(cx, event);
     }
 }
 

--- a/src/widget/linear_layout.rs
+++ b/src/widget/linear_layout.rs
@@ -1,7 +1,3 @@
-// use ratatui::{layout::Rect, prelude::layout::Size};
-
-// use crate::Point;
-
 use crate::geometry::{Axis, Size};
 
 use super::{

--- a/src/widget/text.rs
+++ b/src/widget/text.rs
@@ -5,7 +5,9 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::geometry::{to_ratatui_rect, Size};
 
-use super::{core::EventCx, ChangeFlags, Event, LayoutCx, PaintCx, StyleableWidget, Widget};
+use super::{
+    core::EventCx, BoxConstraints, ChangeFlags, Event, LayoutCx, PaintCx, StyleableWidget, Widget,
+};
 
 pub struct Text {
     pub(crate) text: Cow<'static, str>,
@@ -46,14 +48,15 @@ impl Widget for Text {
 
         let max_width = rect.width.min(term_size.width.saturating_sub(rect.x)) as usize;
         if rect.height > 0 && max_width > 0 && rect.y < term_size.height {
+            // TODO cut the text off, when it is out of bounds (rect.height is not respected)
+            // likely with a custom implementation to render the text, instead of `set_stringn`
             cx.terminal
                 .current_buffer_mut()
                 .set_stringn(rect.x, rect.y, &self.text, max_width, style);
         }
     }
 
-    fn layout(&mut self, _cx: &mut LayoutCx, _bc: &super::BoxConstraints) -> Size {
-        // TODO this currently violates the box constraints, this should in some way wrap, or cut off the text
+    fn layout(&mut self, _cx: &mut LayoutCx, bc: &BoxConstraints) -> Size {
         let mut width = 0;
         let mut height = 0;
 
@@ -62,10 +65,10 @@ impl Widget for Text {
             height += 1;
         }
 
-        Size {
+        bc.constrain(Size {
             width: width as f64,
             height: height as f64,
-        }
+        })
     }
 
     fn event(&mut self, _cx: &mut EventCx, _event: &Event) {}
@@ -123,7 +126,7 @@ impl Widget for WrappedText {
         todo!()
     }
 
-    fn layout(&mut self, _cx: &mut LayoutCx, _bc: &super::BoxConstraints) -> Size {
+    fn layout(&mut self, _cx: &mut LayoutCx, _bc: &BoxConstraints) -> Size {
         todo!()
     }
 


### PR DESCRIPTION
I did some exploration and came back to the conclusion to use BoxConstraints for a base layouting protocol, used in Flutter and Jetpack Compose. (After trying the SwiftUI layout protocol which, it seems is not as powerful as BoxConstraints, SwiftUI seems to do internal layout magic, that isn't really documented).

BoxConstraints seem to work well in Flutter and Jetpack Compose and are simple to understand.

This cop... ehhm adapts the layouting system to BoxConstraints as used in Xilem. (I think it is time to attribute where most of the code comes from (Adding license and mentions etc.)) This shifts a little bit towards being *the* xilem TUI implementation (e.g. use kurbo etc. basically the same base as Xilem). But it remains to be seen whether it diverges in the future (e.g. styling or layouting etc.).

It changes the layouting behavior currently (by "hugging"). I expect to add more layout modifiers soon to control the layout behavior.

The `WrappedText` widget doesn't work anymore, this needs some bigger refactor and rethinking for styling text in general (it was never meant to be more than just a quick'n dirty experiment anyway).