### PR TITLE
Add `WeightedLinearLayout` View/Widget

### DIFF
--- a/examples/blocks.rs
+++ b/examples/blocks.rs
@@ -6,11 +6,12 @@ use trui::*;
 
 fn main() -> Result<()> {
     let view = Arc::new(
-        block(h_stack((
+        block(weighted_h_stack((
             v_stack((
                 // block(("With".fg(Color::Yellow), " background").wrapped()).bg(Color::LightYellow),
                 block("text inside block").with_borders(BorderKind::Straight),
-            )),
+            ))
+            .weight(1.5),
             v_stack((
                 block("Styled title".bg(Color::Red).fg(Color::White)).bg(Color::LightCyan),
                 block(v_stack((

--- a/src/view.rs
+++ b/src/view.rs
@@ -6,6 +6,9 @@ mod events;
 mod linear_layout;
 mod text;
 mod use_state;
+mod weighted_linear_layout;
+
+use std::marker::PhantomData;
 
 use ratatui::style::{Color, Style};
 pub use xilem_core::{Id, IdPath, VecSplice};
@@ -19,6 +22,7 @@ pub use events::*;
 pub use linear_layout::*;
 pub use text::*;
 pub use use_state::*;
+pub use weighted_linear_layout::*;
 
 // TODO this could maybe also be added directly to `View` (possibly copying the macro expanded version of it
 /// A trait that makes it possible to use core views such as [`Adapt`] in the continuation/builder style.
@@ -43,6 +47,14 @@ pub trait ViewExt<T, A>: View<T, A> + Sized {
         OnClick {
             view: self,
             event_handler,
+        }
+    }
+
+    fn weight(self, weight: f64) -> WeightedLayoutElement<Self, T, A> {
+        WeightedLayoutElement {
+            content: self,
+            weight,
+            phantom: PhantomData,
         }
     }
 

--- a/src/view/weighted_linear_layout.rs
+++ b/src/view/weighted_linear_layout.rs
@@ -1,0 +1,132 @@
+use super::{Cx, View, ViewMarker, ViewSequence};
+use crate::{
+    geometry::Axis,
+    widget::{self, ChangeFlags},
+};
+use std::{any::Any, marker::PhantomData};
+use xilem_core::{Id, MessageResult, VecSplice};
+
+pub struct WeightedLinearLayout<T, A, VT> {
+    children: VT,
+    axis: Axis,
+    phantom: PhantomData<fn() -> (T, A)>,
+}
+
+impl<T, A, VT> ViewMarker for WeightedLinearLayout<T, A, VT> {}
+
+impl<T, A, VT: ViewSequence<T, A>> View<T, A> for WeightedLinearLayout<T, A, VT> {
+    type State = VT::State;
+
+    type Element = widget::WeightedLinearLayout;
+
+    fn build(&self, cx: &mut Cx) -> (Id, Self::State, Self::Element) {
+        let mut elements = vec![];
+        let (id, state) = cx.with_new_id(|cx| self.children.build(cx, &mut elements));
+        let column = widget::WeightedLinearLayout::new(elements, self.axis);
+        (id, state, column)
+    }
+
+    fn rebuild(
+        &self,
+        cx: &mut Cx,
+        prev: &Self,
+        id: &mut Id,
+        state: &mut Self::State,
+        element: &mut Self::Element,
+    ) -> ChangeFlags {
+        let mut scratch = vec![];
+        let mut splice = VecSplice::new(&mut element.children, &mut scratch);
+
+        cx.with_id(*id, |cx| {
+            self.children
+                .rebuild(cx, &prev.children, state, &mut splice)
+        })
+    }
+
+    fn message(
+        &self,
+        id_path: &[Id],
+        state: &mut Self::State,
+        event: Box<dyn Any>,
+        app_state: &mut T,
+    ) -> xilem_core::MessageResult<A> {
+        self.children.message(id_path, state, event, app_state)
+    }
+}
+
+pub fn weighted_h_stack<T, A, VT: ViewSequence<T, A>>(
+    children: VT,
+) -> WeightedLinearLayout<T, A, VT> {
+    WeightedLinearLayout {
+        children,
+        axis: Axis::Horizontal,
+        phantom: PhantomData,
+    }
+}
+
+pub fn weighted_v_stack<T, A, VT: ViewSequence<T, A>>(
+    children: VT,
+) -> WeightedLinearLayout<T, A, VT> {
+    WeightedLinearLayout {
+        children,
+        axis: Axis::Vertical,
+        phantom: PhantomData,
+    }
+}
+
+pub struct WeightedLayoutElement<V, T, A> {
+    pub(crate) content: V,
+    pub(crate) weight: f64,
+    pub(crate) phantom: PhantomData<fn() -> (T, A)>,
+}
+
+impl<T, A, V> ViewMarker for WeightedLayoutElement<V, T, A> {}
+
+impl<T, A, V: View<T, A>> View<T, A> for WeightedLayoutElement<V, T, A> {
+    type State = V::State;
+
+    type Element = widget::WeightedLayoutElement;
+
+    fn build(&self, cx: &mut Cx) -> (xilem_core::Id, Self::State, Self::Element) {
+        let (id, state, element) = self.content.build(cx);
+        let element = widget::WeightedLayoutElement::new(element, self.weight);
+        (id, state, element)
+    }
+
+    fn rebuild(
+        &self,
+        cx: &mut Cx,
+        prev: &Self,
+        id: &mut xilem_core::Id,
+        state: &mut Self::State,
+        element: &mut Self::Element,
+    ) -> crate::widget::ChangeFlags {
+        let mut changeflags = ChangeFlags::empty();
+        changeflags |= element.set_weight(self.weight);
+
+        let element = element
+            .content
+            .downcast_mut()
+            .expect("The weighted widget changed its type, this should never happen!");
+
+        changeflags | self.content.rebuild(cx, &prev.content, id, state, element)
+    }
+
+    fn message(
+        &self,
+        id_path: &[xilem_core::Id],
+        state: &mut Self::State,
+        message: Box<dyn std::any::Any>,
+        app_state: &mut T,
+    ) -> MessageResult<A> {
+        self.content.message(id_path, state, message, app_state)
+    }
+}
+
+pub fn weighted<T, A, V: View<T, A>>(weight: f64, content: V) -> WeightedLayoutElement<V, T, A> {
+    WeightedLayoutElement {
+        content,
+        weight,
+        phantom: PhantomData,
+    }
+}

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -4,6 +4,7 @@ mod core;
 mod events;
 mod linear_layout;
 mod text;
+mod weighted_linear_layout;
 
 pub use self::core::{
     AnyWidget, ChangeFlags, CxState, Event, EventCx, LayoutCx, LifeCycleCx, Message, PaintCx, Pod,
@@ -15,3 +16,4 @@ pub use box_constraints::BoxConstraints;
 pub use events::*;
 pub(crate) use linear_layout::LinearLayout;
 pub(crate) use text::*;
+pub(crate) use weighted_linear_layout::{WeightedLayoutElement, WeightedLinearLayout};

--- a/src/widget/weighted_linear_layout.rs
+++ b/src/widget/weighted_linear_layout.rs
@@ -1,0 +1,119 @@
+use crate::geometry::{Axis, Size};
+
+use super::{
+    core::{EventCx, PaintCx},
+    BoxConstraints, ChangeFlags, LayoutCx, Pod, Widget,
+};
+
+pub struct WeightedLinearLayout {
+    pub children: Vec<Pod>,
+    pub weights: Vec<f64>,
+    pub axis: Axis,
+}
+
+pub struct WeightedLayoutElement {
+    pub(crate) content: Pod,
+    weight: f64,
+}
+
+impl WeightedLayoutElement {
+    pub(crate) fn new(content: impl Widget, weight: f64) -> Self {
+        Self {
+            content: Pod::new(content),
+            weight,
+        }
+    }
+    pub(crate) fn set_weight(&mut self, weight: f64) -> ChangeFlags {
+        if self.weight != weight {
+            self.weight = weight;
+            ChangeFlags::LAYOUT
+        } else {
+            ChangeFlags::empty()
+        }
+    }
+}
+
+impl Widget for WeightedLayoutElement {
+    fn paint(&mut self, cx: &mut PaintCx) {
+        self.content.paint(cx)
+    }
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &BoxConstraints) -> Size {
+        self.content.layout(cx, bc)
+    }
+    fn lifecycle(&mut self, cx: &mut super::LifeCycleCx, event: &super::LifeCycle) {
+        self.content.lifecycle(cx, event)
+    }
+    fn event(&mut self, cx: &mut EventCx, event: &super::Event) {
+        self.content.event(cx, event)
+    }
+}
+
+fn get_weights(children: &[Pod], weights: &mut Vec<f64>) -> f64 {
+    weights.clear();
+    let mut sum = 0.0;
+    for child in children {
+        let weight = if let Some(weighted_el) = child.downcast_ref::<WeightedLayoutElement>() {
+            weighted_el.weight
+        } else {
+            1.0
+        };
+        sum += weight;
+        weights.push(weight);
+    }
+    sum
+}
+
+impl WeightedLinearLayout {
+    pub(crate) fn new(children: Vec<Pod>, axis: Axis) -> Self {
+        let weights = Vec::with_capacity(children.len());
+        WeightedLinearLayout {
+            children,
+            axis,
+            weights,
+        }
+    }
+}
+
+impl Widget for WeightedLinearLayout {
+    fn paint(&mut self, cx: &mut PaintCx) {
+        for child in self.children.iter_mut() {
+            child.paint(cx);
+        }
+    }
+
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &BoxConstraints) -> Size {
+        let mut major_used: f64 = 0.0;
+        let mut max_minor: f64 = 0.0;
+
+        let total_weight_inv = 1.0 / get_weights(&self.children, &mut self.weights);
+        let space_available = self.axis.major(*bc).end;
+
+        for (index, child) in self.children.iter_mut().enumerate() {
+            let constraint = if space_available != f64::INFINITY {
+                let size = space_available * (self.weights[index] * total_weight_inv);
+                size..size
+            } else {
+                0.0..f64::INFINITY
+            };
+            let child_bc = self.axis.with_major(*bc, constraint);
+            let size = child.layout(cx, &child_bc);
+            child.set_origin(cx, self.axis.pack(major_used, 0.0));
+            major_used += self.axis.major(size);
+            max_minor = max_minor.max(self.axis.minor(size));
+        }
+
+        self.axis.pack(major_used, max_minor)
+    }
+
+    fn event(&mut self, cx: &mut EventCx, event: &super::Event) {
+        for child in &mut self.children {
+            child.event(cx, event);
+        }
+    }
+
+    fn lifecycle(&mut self, cx: &mut super::core::LifeCycleCx, event: &super::LifeCycle) {
+        for child in &mut self.children {
+            child.lifecycle(cx, event);
+        }
+    }
+}


### PR DESCRIPTION
This forces all children to have a weighted size,
instead of giving the freedom to choose their size via constraints. By default a view has a weight of 1.0, this can be overridden via the `WeightedLayoutElement` (or `view.weight(f64)`)

One possibly interesting pattern here is the dynamic cast of the type (`WeightedLayoutElement`) and when it fails a default of 1.0 is chosen.

This pattern could be used in other contexts as well to avoid having to wrap all views in context-specific types such as the `WeightedLayoutElement`.

There are (slight) disadvantages though,
One is that it doesn't cascade.
So something like `view.weight(1.5).other_modifier()` does have no effect (or rather has a default weight of 1.0) in the `WeightedLinearLayout` context.
It can also be used in different contexts where it doesn't make sense (It does not have any effect there). So it would be interesting to explore more statically enforced solutions still (while not unnecessarily increasing type complexity)