### PR TITLE
Add `Margin` View/Widget

### DIFF
--- a/examples/blocks.rs
+++ b/examples/blocks.rs
@@ -9,15 +9,23 @@ fn main() -> Result<()> {
         block(weighted_h_stack((
             v_stack((
                 // block(("With".fg(Color::Yellow), " background").wrapped()).bg(Color::LightYellow),
-                block("text inside block").with_borders(BorderKind::Straight),
+                block("text inside block")
+                    .with_borders(BorderKind::Straight)
+                    .margin((Position::VERTICAL, 2)),
             ))
             .weight(1.5),
             v_stack((
                 block("Styled title".bg(Color::Red).fg(Color::White)).bg(Color::LightCyan),
-                block(v_stack((
-                    "With styled borders and doubled borders",
-                    block("Block inside block").with_borders(BorderKind::Straight),
-                )))
+                block(
+                    v_stack((
+                        "With styled borders and doubled borders",
+                        block("Block inside block")
+                            .with_borders(BorderKind::Straight)
+                            .margin(2),
+                    ))
+                    .margin((Position::TOP, 1))
+                    .margin((Position::HORIZONTAL, 2)),
+                )
                 .with_borders((
                     Borders::VERTICAL,
                     Style::default().fg(Color::Cyan),

--- a/src/view.rs
+++ b/src/view.rs
@@ -4,6 +4,7 @@ mod core;
 mod defer;
 mod events;
 mod linear_layout;
+mod margin;
 mod text;
 mod use_state;
 mod weighted_linear_layout;
@@ -20,6 +21,7 @@ pub use common::*;
 pub use defer::*;
 pub use events::*;
 pub use linear_layout::*;
+pub use margin::*;
 pub use text::*;
 pub use use_state::*;
 pub use weighted_linear_layout::*;
@@ -41,6 +43,16 @@ pub trait ViewExt<T, A>: View<T, A> + Sized {
         F: Fn(&mut ParentT) -> &mut T + Send + Sync + Send,
     {
         AdaptState::new(f, self)
+    }
+
+    fn margin<S: Into<MarginStyle>>(self, style: S) -> Margin<Self, T, A> {
+        let style = style.into();
+        Margin {
+            content: self,
+            position: style.position,
+            amount: style.amount,
+            phantom: PhantomData,
+        }
     }
 
     fn on_click<EH: EventHandler<T, A>>(self, event_handler: EH) -> OnClick<Self, EH> {

--- a/src/view/common.rs
+++ b/src/view/common.rs
@@ -20,12 +20,26 @@ bitflags! {
         const BOTTOM     = 0b0100;
         /// Show the left border
         const LEFT       = 0b1000;
-        /// Show all borders
-        const ALL        = Self::TOP.bits() | Self::RIGHT.bits() | Self::BOTTOM.bits() | Self::LEFT.bits();
         /// Show top and bottom borders
         const HORIZONTAL = Self::BOTTOM.bits() | Self::TOP.bits();
         /// Show left and right borders
         const VERTICAL   = Self::LEFT.bits() | Self::RIGHT.bits();
+        /// Show all borders
+        const ALL        = Self::HORIZONTAL.bits() | Self::VERTICAL.bits();
+    }
+}
+
+bitflags! {
+    /// Bitflags that can be composed to set the visible borders essentially on the block widget.
+    #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub struct Position: u8 {
+        const TOP        = 0b0001;
+        const RIGHT      = 0b0010;
+        const BOTTOM     = 0b0100;
+        const LEFT       = 0b1000;
+        const HORIZONTAL = Self::LEFT.bits() | Self::RIGHT.bits();
+        const VERTICAL   = Self::TOP.bits() | Self::BOTTOM.bits();
+        const ALL        = Self::HORIZONTAL.bits() | Self::VERTICAL.bits();
     }
 }
 

--- a/src/view/margin.rs
+++ b/src/view/margin.rs
@@ -1,0 +1,85 @@
+use std::marker::PhantomData;
+
+use xilem_core::MessageResult;
+
+use crate::{
+    widget::{self, ChangeFlags},
+    Cx, Position, View, ViewMarker,
+};
+
+pub struct Margin<V, T, A> {
+    pub(crate) content: V,
+    pub(crate) amount: u16,
+    pub(crate) position: Position,
+    pub(crate) phantom: PhantomData<fn() -> (T, A)>,
+}
+
+impl<T, A, V> ViewMarker for Margin<V, T, A> {}
+
+impl<T, A, V: View<T, A>> View<T, A> for Margin<V, T, A> {
+    type State = V::State;
+
+    type Element = widget::Margin;
+
+    fn build(&self, cx: &mut Cx) -> (xilem_core::Id, Self::State, Self::Element) {
+        let (id, state, element) = self.content.build(cx);
+        let element = widget::Margin::new(element, self.position, self.amount);
+        (id, state, element)
+    }
+
+    fn rebuild(
+        &self,
+        cx: &mut Cx,
+        prev: &Self,
+        id: &mut xilem_core::Id,
+        state: &mut Self::State,
+        element: &mut Self::Element,
+    ) -> crate::widget::ChangeFlags {
+        let mut changeflags = ChangeFlags::empty();
+        changeflags |= element.set_amount(self.amount);
+        changeflags |= element.set_position(self.position);
+
+        let element = element
+            .content
+            .downcast_mut()
+            .expect("The margin widget changed its type, this should never happen!");
+
+        changeflags | self.content.rebuild(cx, &prev.content, id, state, element)
+    }
+
+    fn message(
+        &self,
+        id_path: &[xilem_core::Id],
+        state: &mut Self::State,
+        message: Box<dyn std::any::Any>,
+        app_state: &mut T,
+    ) -> MessageResult<A> {
+        self.content.message(id_path, state, message, app_state)
+    }
+}
+
+pub struct MarginStyle {
+    pub amount: u16,
+    pub position: Position,
+}
+
+impl From<u16> for MarginStyle {
+    fn from(amount: u16) -> Self {
+        Self {
+            amount,
+            position: Position::ALL,
+        }
+    }
+}
+
+impl From<(u16, Position)> for MarginStyle {
+    fn from((amount, position): (u16, Position)) -> Self {
+        Self { amount, position }
+    }
+}
+
+impl From<(Position, u16)> for MarginStyle {
+    fn from((position, amount): (Position, u16)) -> Self {
+        Self { amount, position }
+    }
+}

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -3,6 +3,7 @@ mod box_constraints;
 mod core;
 mod events;
 mod linear_layout;
+mod margin;
 mod text;
 mod weighted_linear_layout;
 
@@ -15,5 +16,6 @@ pub(crate) use block::Block;
 pub use box_constraints::BoxConstraints;
 pub use events::*;
 pub(crate) use linear_layout::LinearLayout;
+pub(crate) use margin::Margin;
 pub(crate) use text::*;
 pub(crate) use weighted_linear_layout::{WeightedLayoutElement, WeightedLinearLayout};

--- a/src/widget/events.rs
+++ b/src/widget/events.rs
@@ -7,7 +7,7 @@ use ratatui::style::Style;
 
 use super::{
     core::{IdPath, PaintCx},
-    ChangeFlags, Event, EventCx, LayoutCx, Message, Pod, Widget,
+    Event, EventCx, LayoutCx, Message, Pod, Widget,
 };
 
 #[derive(Debug)]

--- a/src/widget/margin.rs
+++ b/src/widget/margin.rs
@@ -1,0 +1,77 @@
+use crate::{
+    geometry::{Point, Size},
+    Position,
+};
+
+use super::{
+    core::{EventCx, LifeCycleCx, PaintCx},
+    BoxConstraints, ChangeFlags, Event, LayoutCx, LifeCycle, Pod, Widget,
+};
+
+pub struct Margin {
+    pub(crate) content: Pod,
+    amount: u16,
+    position: Position,
+}
+
+impl Margin {
+    pub(crate) fn new(content: impl Widget, position: Position, amount: u16) -> Self {
+        Margin {
+            content: Pod::new(content),
+            amount,
+            position,
+        }
+    }
+
+    pub(crate) fn set_amount(&mut self, amount: u16) -> ChangeFlags {
+        if self.amount != amount {
+            self.amount = amount;
+            ChangeFlags::LAYOUT
+        } else {
+            ChangeFlags::empty()
+        }
+    }
+
+    pub(crate) fn set_position(&mut self, position: Position) -> ChangeFlags {
+        if self.position != position {
+            self.position = position;
+            ChangeFlags::LAYOUT
+        } else {
+            ChangeFlags::empty()
+        }
+    }
+}
+
+impl Widget for Margin {
+    fn paint(&mut self, cx: &mut PaintCx) {
+        self.content.paint(cx)
+    }
+
+    fn layout(&mut self, cx: &mut LayoutCx, bc: &BoxConstraints) -> Size {
+        let margin = |position| {
+            if self.position.contains(position) {
+                self.amount as f64
+            } else {
+                0.0
+            }
+        };
+        let margin_top = margin(Position::TOP);
+        let margin_bottom = margin(Position::BOTTOM);
+        let margin_left = margin(Position::LEFT);
+        let margin_right = margin(Position::RIGHT);
+        let margin = Size::new(margin_left + margin_right, margin_top + margin_bottom);
+        let content_size = self.content.layout(cx, &bc.shrink(margin));
+
+        self.content
+            .set_origin(cx, Point::new(margin_left, margin_top));
+        content_size + margin
+    }
+
+    fn event(&mut self, cx: &mut EventCx, event: &Event) {
+        self.content.event(cx, event)
+    }
+
+    fn lifecycle(&mut self, cx: &mut LifeCycleCx, event: &LifeCycle) {
+        self.content.lifecycle(cx, event)
+    }
+}


### PR DESCRIPTION
This adds a `Margin` view, which adds margins around a composed widget. It uses a similar styling pattern as the `Block` View via `view.margin(impl Into<MarginStyle>)`