### PR TITLE
Fix print_buffer

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -371,9 +371,13 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
         }
     }
 
-    pub fn run(mut self) -> Result<()> {
+    pub fn run(self) -> Result<()> {
         let _guard = setup_logging(tracing::Level::DEBUG)?;
+        self.run_without_logging()
+    }
 
+    // TODO(zoechi): setup proper configuration for App
+    pub fn run_without_logging(mut self) -> Result<()> {
         #[cfg(not(test))]
         self.init_terminal()?;
 

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -223,6 +223,7 @@ pub fn print_buffer(buffer: &Buffer) -> std::io::Result<()> {
         terminal.clear()?;
         terminal.current_buffer_mut().clone_from(buffer);
         terminal.flush()?;
+        crossterm::queue!(stdout(), crossterm::cursor::MoveTo(0, buffer.area.height))?;
     };
     Ok(())
 }

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -3,9 +3,6 @@ use std::io::stdout;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use crossterm::cursor::MoveToNextLine;
-use crossterm::execute;
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use ratatui::backend::TestBackend;
 use ratatui::layout::Size;
 use ratatui::prelude::*;
@@ -208,7 +205,7 @@ impl Widget for DebugWidget {
 /// dumped to stdout.
 ///
 /// ```sh
-/// DEBUG_SNAPSHOT=1 cargo test --lib -- --nocapture --test simple_block_test
+/// DEBUG_SNAPSHOT=1 cargo test --lib -- --show-output --test simple_block_test
 /// ```
 ///
 /// !!! The normal test output frequently interferes which results in scrambled output, especially
@@ -216,18 +213,16 @@ impl Widget for DebugWidget {
 /// Running it multiple times might usually leads to good output (for now, with small widget output)
 pub fn print_buffer(buffer: &Buffer) -> std::io::Result<()> {
     if env::var("DEBUG_SNAPSHOT").is_ok() {
-        enable_raw_mode()?;
-        execute!(stdout(), MoveToNextLine(0))?;
         let mut terminal = Terminal::with_options(
             CrosstermBackend::new(stdout()),
             TerminalOptions {
-                viewport: Viewport::Inline(buffer.area.height),
+                viewport: Viewport::Fixed(buffer.area),
             },
         )?;
+
+        terminal.clear()?;
         terminal.current_buffer_mut().clone_from(buffer);
         terminal.flush()?;
-        execute!(stdout(), MoveToNextLine(0))?;
-        disable_raw_mode()?;
     };
     Ok(())
 }

--- a/src/view/block.rs
+++ b/src/view/block.rs
@@ -330,4 +330,18 @@ mod tests {
 
         insta::assert_debug_snapshot!(buffer);
     }
+
+    #[test]
+    fn too_small_block() {
+        let sut = Arc::new(block("some text".fg(Color::Cyan)).with_borders(BorderKind::Straight));
+        let buffer = render_view(
+            Size {
+                width: 7,
+                height: 5,
+            },
+            sut,
+            AppState,
+        );
+        insta::assert_debug_snapshot!(buffer);
+    }
 }

--- a/src/view/block.rs
+++ b/src/view/block.rs
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn simple_block_test() {
-        let sut = Arc::new(block("some text".fg(Color::Cyan)));
+        let sut = Arc::new(block("some text".fg(Color::Cyan)).with_borders(BorderKind::Straight));
         let buffer = render_view(
             Size {
                 width: 15,

--- a/src/view/snapshots/trui__view__block__tests__simple_block_test.snap
+++ b/src/view/snapshots/trui__view__block__tests__simple_block_test.snap
@@ -5,14 +5,15 @@ expression: buffer
 Buffer {
     area: Rect { x: 0, y: 0, width: 15, height: 5 },
     content: [
-        "some text      ",
-        "               ",
-        "               ",
-        "               ",
-        "               ",
+        "┌─────────────┐",
+        "│some text    │",
+        "│             │",
+        "│             │",
+        "└─────────────┘",
     ],
     styles: [
-        x: 0, y: 0, fg: Cyan, bg: Reset, underline: Reset, modifier: NONE,
-        x: 9, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 1, fg: Cyan, bg: Reset, underline: Reset, modifier: NONE,
+        x: 10, y: 1, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
     ]
 }

--- a/src/view/snapshots/trui__view__block__tests__too_small_block.snap
+++ b/src/view/snapshots/trui__view__block__tests__too_small_block.snap
@@ -1,0 +1,19 @@
+---
+source: src/view/block.rs
+expression: buffer
+---
+Buffer {
+    area: Rect { x: 0, y: 0, width: 7, height: 5 },
+    content: [
+        "┌─────┐",
+        "│some │",
+        "│     │",
+        "│     │",
+        "└─────┘",
+    ],
+    styles: [
+        x: 0, y: 0, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+        x: 1, y: 1, fg: Cyan, bg: Reset, underline: Reset, modifier: NONE,
+        x: 6, y: 1, fg: Reset, bg: Reset, underline: Reset, modifier: NONE,
+    ]
+}


### PR DESCRIPTION
It's still not perfect, but I think it's pretty useful already. A nuisance is that the test output starts immediately after the last character in the last line of the widget.
I haven't found a way to prevent that.