### PR TITLE
Enable doctests in CI again with test configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,7 @@ rand = "0.8"
 
 [lints.clippy]
 dbg_macro = "warn"
+
+[features]
+# INTERNAL USE ONLY, workaround for https://github.com/rust-lang/rust/issues/67295
+doctests = []

--- a/src/app.rs
+++ b/src/app.rs
@@ -27,7 +27,9 @@ use ratatui::Terminal;
 use std::io::stdout;
 
 use std::{
-    collections::HashSet, sync::Arc, time::{Duration, Instant}
+    collections::HashSet,
+    sync::Arc,
+    time::{Duration, Instant},
 };
 use tracing_subscriber::{fmt::writer::MakeWriterExt, layer::SubscriberExt, Registry};
 use xilem_core::{AsyncWake, Id, IdPath, MessageResult};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,5 @@ pub use ratatui::style::{Color, Modifier, Style};
 pub use view::*;
 pub use widget::CatchMouseButton;
 
-#[cfg(any(test, doctest))]
+#[cfg(test)]
 mod test_helper;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,5 +9,5 @@ pub use ratatui::style::{Color, Modifier, Style};
 pub use view::*;
 pub use widget::CatchMouseButton;
 
-#[cfg(test)]
+#[cfg(any(test, doctest))]
 mod test_helper;

--- a/src/view.rs
+++ b/src/view.rs
@@ -61,14 +61,15 @@ pub trait ViewExt<T, A>: View<T, A> + Sized {
 
     // TODO these doctests should work without ignore, but need a TestBackend as terminal backend in CI
     /// # Examples
-    /// ```ignore
-    /// use trui::*;
-    /// App::new((), move |()| {
-    ///    v_stack((
-    ///        "Text with border".border(BorderKind::Rounded),
-    ///        "Other style".border((Borders::VERTICAL, Style::default().fg(Color::Red))),
-    ///    ))
-    /// });
+    /// ```
+    /// # use trui::*;
+    /// # App::new((), move |()| {
+    /// v_stack((
+    ///     "Rounded borders".border(BorderKind::Rounded),
+    ///     "Red borders left and right".border((Borders::VERTICAL, Style::default().fg(Color::Red))),
+    ///     "Top and right but without corners".border(Borders::TOP | Borders::RIGHT),
+    /// ))
+    /// # });
     /// ```
     fn border<S: Into<BorderStyle>>(self, style: S) -> Border<Self, T, A> {
         let style = style.into();
@@ -82,13 +83,13 @@ pub trait ViewExt<T, A>: View<T, A> + Sized {
     }
 
     /// # Examples
-    /// ```ignore
-    /// use trui::*;
-    /// App::new((), move |()| {
-    ///    "Fill half of the parent width/height"
-    ///        .border(BorderKind::Rounded)
-    ///        .fill_max_size(0.5)
-    /// });
+    /// ```
+    /// # use trui::*;
+    /// # App::new((), move |()| {
+    /// "Fill half of the parent width/height"
+    ///     .border(BorderKind::Rounded)
+    ///     .fill_max_size(0.5)
+    /// # });
     /// ```
     fn fill_max_size<P: Animatable<f64>, S: IntoFillMaxSizeStyle<P>>(
         self,

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,10 +1,10 @@
 mod border;
 mod box_constraints;
 
-#[cfg(not(any(test, doctest)))]
+#[cfg(not(any(test, doctest, feature = "doctests")))]
 mod core;
 
-#[cfg(any(test, doctest))]
+#[cfg(any(test, doctest, feature = "doctests"))]
 pub(crate) mod core;
 
 mod events;

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,10 +1,10 @@
 mod border;
 mod box_constraints;
 
-#[cfg(not(test))]
+#[cfg(not(any(test, doctest)))]
 mod core;
 
-#[cfg(test)]
+#[cfg(any(test, doctest))]
 pub(crate) mod core;
 
 mod events;

--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -6,13 +6,13 @@ use ratatui::Terminal;
 use std::{any::Any, ops::DerefMut};
 use xilem_core::{message, Id};
 
-#[cfg(test)]
+#[cfg(any(test, doctest))]
 use ratatui::backend::TestBackend;
 
-#[cfg(not(test))]
+#[cfg(not(any(test, doctest)))]
 use ratatui::backend::CrosstermBackend;
 
-#[cfg(not(test))]
+#[cfg(not(any(test, doctest)))]
 use std::io::Stdout;
 
 message!(Send);
@@ -55,10 +55,10 @@ pub struct PaintCx<'a, 'b> {
     // TODO mutable? (xilem doesn't do this, but I think there are use cases for this...)
     pub(crate) widget_state: &'a mut WidgetState,
 
-    #[cfg(test)]
+    #[cfg(any(test, doctest))]
     pub(crate) terminal: &'a mut Terminal<TestBackend>,
 
-    #[cfg(not(test))]
+    #[cfg(not(any(test, doctest)))]
     pub(crate) terminal: &'a mut Terminal<CrosstermBackend<Stdout>>,
     // TODO this kinda feels hacky, find a better solution for this issue:
     // this is currently necessary because the most outer styleable widget should be able to override the style for a styleable widget

--- a/src/widget/core.rs
+++ b/src/widget/core.rs
@@ -6,13 +6,13 @@ use ratatui::Terminal;
 use std::{any::Any, ops::DerefMut};
 use xilem_core::{message, Id};
 
-#[cfg(any(test, doctest))]
+#[cfg(any(test, doctest, feature = "doctests"))]
 use ratatui::backend::TestBackend;
 
-#[cfg(not(any(test, doctest)))]
+#[cfg(not(any(test, doctest, feature = "doctests")))]
 use ratatui::backend::CrosstermBackend;
 
-#[cfg(not(any(test, doctest)))]
+#[cfg(not(any(test, doctest, feature = "doctests")))]
 use std::io::Stdout;
 
 message!(Send);
@@ -55,10 +55,10 @@ pub struct PaintCx<'a, 'b> {
     // TODO mutable? (xilem doesn't do this, but I think there are use cases for this...)
     pub(crate) widget_state: &'a mut WidgetState,
 
-    #[cfg(any(test, doctest))]
+    #[cfg(any(test, doctest, feature = "doctests"))]
     pub(crate) terminal: &'a mut Terminal<TestBackend>,
 
-    #[cfg(not(any(test, doctest)))]
+    #[cfg(not(any(test, doctest, feature = "doctests")))]
     pub(crate) terminal: &'a mut Terminal<CrosstermBackend<Stdout>>,
     // TODO this kinda feels hacky, find a better solution for this issue:
     // this is currently necessary because the most outer styleable widget should be able to override the style for a styleable widget


### PR DESCRIPTION
`cfg(test)` is not set when running doc tests.
This enables `cfg(doctest)` everywhere where `cfg(test)` is set (to use the `ratatui::TestBackend`)