### PR TITLE
Configurable async runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,23 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
  "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -37,9 +46,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "arrayvec"
@@ -48,10 +57,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -69,6 +156,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +172,12 @@ name = "bitflags"
 version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -103,12 +202,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 
 [[package]]
 name = "cfg-if"
@@ -142,6 +238,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "console-api"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
+dependencies = [
+ "futures-core",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tracing-core",
+]
+
+[[package]]
+name = "console-subscriber"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7481d4c57092cd1c19dd541b92bdce883de840df30aa5d03fd48a3935c01842e"
+dependencies = [
+ "console-api",
+ "crossbeam-channel",
+ "crossbeam-utils",
+ "futures-task",
+ "hdrhistogram",
+ "humantime",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thread_local",
+ "tokio",
+ "tokio-stream",
+ "tonic",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +306,7 @@ checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
  "bitflags 2.4.2",
  "crossterm_winapi",
+ "futures-core",
  "libc",
  "mio",
  "parking_lot",
@@ -213,15 +356,37 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
@@ -279,7 +444,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -330,6 +495,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "h2"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.2.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +530,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "base64",
+ "byteorder",
+ "flate2",
+ "nom",
+ "num-traits",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,9 +550,105 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
+checksum = "379dada1584ad501b383485dd706b8afb7a70fcbc7f4da7d780638a5a6124a60"
+
+[[package]]
+name = "http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
+]
 
 [[package]]
 name = "indoc"
@@ -359,15 +658,24 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "insta"
-version = "1.34.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc"
+checksum = "7c985c1bef99cf13c58fade470483d81a2bfe846ebde60ed28cc2dddec2df9e2"
 dependencies = [
  "console",
  "lazy_static",
  "linked-hash-map",
  "similar",
  "yaml-rust",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -442,18 +750,45 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "lru"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.14.3",
 ]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -477,6 +812,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +836,15 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_cpus"
@@ -559,6 +913,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +969,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -632,16 +1044,16 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154b85ef15a5d1719bcaa193c3c81fe645cd120c156874cd660fe49fd21d1373"
+checksum = "bcb12f8fbf6c62614b0d56eb352af54f6a22410c3b079eb53ee93c7b97dd31d8"
 dependencies = [
  "bitflags 2.4.2",
  "cassowary",
  "compact_str",
  "crossterm",
  "indoc",
- "itertools",
+ "itertools 0.12.1",
  "lru",
  "paste",
  "stability",
@@ -671,6 +1083,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,9 +1140,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "scopeguard"
@@ -696,22 +1152,33 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -776,12 +1243,12 @@ checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -819,7 +1286,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -835,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "6ab617d94515e94ae53b8406c628598680aa0c9587474ecbe58188f7b345d66c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -845,30 +1312,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.56"
+name = "sync_wrapper"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "thiserror"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -921,7 +1394,18 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -932,8 +1416,92 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -966,7 +1534,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -996,10 +1564,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -1010,6 +1582,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.2",
+ "console-subscriber",
  "crossterm",
  "directories",
  "futures",
@@ -1027,6 +1600,12 @@ dependencies = [
  "unicode-width",
  "xilem_core",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
@@ -1057,6 +1636,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -1101,7 +1689,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -1121,17 +1709,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "d380ba1dc7187569a8a9e91ed34b8ccfc33123bbacb8c0aed2d1ad7f3ef2dc5f"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.3",
+ "windows_aarch64_msvc 0.52.3",
+ "windows_i686_gnu 0.52.3",
+ "windows_i686_msvc 0.52.3",
+ "windows_x86_64_gnu 0.52.3",
+ "windows_x86_64_gnullvm 0.52.3",
+ "windows_x86_64_msvc 0.52.3",
 ]
 
 [[package]]
@@ -1142,9 +1730,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "68e5dcfb9413f53afd9c8f86e56a7b4d86d9a2fa26090ea2dc9e40fba56c6ec6"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -1154,9 +1742,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "8dab469ebbc45798319e69eebf92308e541ce46760b49b18c6b3fe5e8965b30f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1166,9 +1754,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "2a4e9b6a7cac734a8b4138a4e1044eac3404d8326b6c0f939276560687a033fb"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1178,9 +1766,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "28b0ec9c422ca95ff34a78755cfa6ad4a51371da2a5ace67500cf7ca5f232c58"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1190,9 +1778,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "704131571ba93e89d7cd43482277d6632589b18ecf4468f591fbae0a8b101614"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1202,9 +1790,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "42079295511643151e98d61c38c0acc444e52dd42ab456f7ccfd5152e8ecf21c"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1214,14 +1802,14 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "xilem_core"
 version = "0.1.0"
-source = "git+https://github.com/Philipp-M/xilem.git?branch=personal#f876cb7b6df3b964e00b6f191b72fe5664407943"
+source = "git+https://github.com/Philipp-M/xilem.git?branch=personal#c00f4c229974d3eda21232d8f5f1f4ab99229614"
 
 [[package]]
 name = "yaml-rust"
@@ -1249,5 +1837,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.51",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ ratatui = "0.26"
 tokio = { version = "1.35", features = ["full"] }
 tracing = "0.1"
 tracing-appender = "0.2"
-tracing-subscriber = "0.3"
 unicode-segmentation = "1.11"
 unicode-width = "0.1"
 
@@ -25,6 +24,7 @@ unicode-width = "0.1"
 futures = "0.3"
 insta = "1.34"
 rand = "0.8"
+tracing-subscriber = "0.3"
 
 [lints.clippy]
 dbg_macro = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,12 @@ edition = "2021"
 xilem_core = { git = "https://github.com/Philipp-M/xilem.git", branch = "personal" }
 anyhow = "1.0"
 bitflags = "2.4"
-crossterm = "0.27"
+crossterm = { version = "0.27", features = ["event-stream"] }
 directories = "5.0"
-kurbo = "0.10"
+futures = "0.3"
 futures-task = "0.3"
 futures-util = "0.3"
+kurbo = "0.10"
 ratatui = "0.26"
 tokio = { version = "1.35", features = ["full"] }
 tracing = "0.1"
@@ -21,7 +22,7 @@ unicode-segmentation = "1.11"
 unicode-width = "0.1"
 
 [dev-dependencies]
-futures = "0.3"
+console-subscriber = "0.2.0"
 insta = "1.34"
 rand = "0.8"
 tracing-subscriber = "0.3"

--- a/examples/animatables.rs
+++ b/examples/animatables.rs
@@ -1,7 +1,6 @@
 use std::{f64::consts::PI, time::Duration};
 
 use anyhow::Result;
-use ratatui::style::{Color, Style};
 use trui::*;
 
 #[path = "./shared/logging.rs"]

--- a/examples/animatables.rs
+++ b/examples/animatables.rs
@@ -2,8 +2,10 @@ use std::{f64::consts::PI, time::Duration};
 
 use anyhow::Result;
 use ratatui::style::{Color, Style};
-use trui::logging::setup_logging;
 use trui::*;
+
+#[path = "./shared/logging.rs"]
+mod logging;
 
 pub fn button<T>(
     content: impl View<T>,
@@ -21,8 +23,10 @@ struct AppState {
     selected_tab: usize,
 }
 
-fn main() -> Result<()> {
-    let _ = setup_logging(tracing::Level::DEBUG)?;
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = crate::logging::setup_logging(tracing::Level::DEBUG)?;
+    tracing::debug!("app start");
 
     App::new(
         AppState {
@@ -112,5 +116,7 @@ fn main() -> Result<()> {
             ))
         },
     )
+    .await
     .run()
+    .await
 }

--- a/examples/animatables.rs
+++ b/examples/animatables.rs
@@ -2,6 +2,7 @@ use std::{f64::consts::PI, time::Duration};
 
 use anyhow::Result;
 use ratatui::style::{Color, Style};
+use trui::logging::setup_logging;
 use trui::*;
 
 pub fn button<T>(
@@ -21,6 +22,8 @@ struct AppState {
 }
 
 fn main() -> Result<()> {
+    let _ = setup_logging(tracing::Level::DEBUG)?;
+
     App::new(
         AppState {
             maximize: false,

--- a/examples/async_event_handler_stream.rs
+++ b/examples/async_event_handler_stream.rs
@@ -3,6 +3,7 @@ use futures::Stream;
 use ratatui::style::Color;
 use std::time::Duration;
 use tokio::time::{interval, sleep};
+use trui::logging::setup_logging;
 use trui::*;
 
 pub fn words_stream(input: &str) -> impl Stream<Item = String> + Send {
@@ -29,6 +30,8 @@ pub fn words_stream(input: &str) -> impl Stream<Item = String> + Send {
 }
 
 fn main() -> Result<()> {
+    let _ = setup_logging(tracing::Level::DEBUG)?;
+
     App::new(String::new(), |app_state| {
         v_stack((
             "Click me for some non-sense"

--- a/examples/async_event_handler_stream.rs
+++ b/examples/async_event_handler_stream.rs
@@ -3,8 +3,10 @@ use futures::Stream;
 use ratatui::style::Color;
 use std::time::Duration;
 use tokio::time::{interval, sleep};
-use trui::logging::setup_logging;
 use trui::*;
+
+#[path = "./shared/logging.rs"]
+mod logging;
 
 pub fn words_stream(input: &str) -> impl Stream<Item = String> + Send {
     let words = input
@@ -29,8 +31,9 @@ pub fn words_stream(input: &str) -> impl Stream<Item = String> + Send {
     )
 }
 
-fn main() -> Result<()> {
-    let _ = setup_logging(tracing::Level::DEBUG)?;
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = crate::logging::setup_logging(tracing::Level::DEBUG)?;
 
     App::new(String::new(), |app_state| {
         v_stack((
@@ -93,5 +96,7 @@ fn main() -> Result<()> {
                 }),
         ))
     })
+    .await
     .run()
+    .await
 }

--- a/examples/blocks.rs
+++ b/examples/blocks.rs
@@ -2,9 +2,12 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use ratatui::style::{Color, Style};
+use trui::logging::setup_logging;
 use trui::*;
 
 fn main() -> Result<()> {
+    let _ = setup_logging(tracing::Level::DEBUG)?;
+
     let view = Arc::new(
         weighted_h_stack((
             "text inside block"

--- a/examples/blocks.rs
+++ b/examples/blocks.rs
@@ -2,11 +2,14 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use ratatui::style::{Color, Style};
-use trui::logging::setup_logging;
 use trui::*;
 
-fn main() -> Result<()> {
-    let _ = setup_logging(tracing::Level::DEBUG)?;
+#[path = "./shared/logging.rs"]
+mod logging;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = crate::logging::setup_logging(tracing::Level::DEBUG)?;
 
     let view = Arc::new(
         weighted_h_stack((
@@ -38,5 +41,5 @@ fn main() -> Result<()> {
         .border(BorderKind::Rounded)
         .margin(1),
     );
-    App::new((), move |()| view.clone()).run()
+    App::new((), move |()| view.clone()).await.run().await
 }

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use ratatui::style::{Color, Style};
-use trui::logging::setup_logging;
 use trui::*;
+
+#[path = "./shared/logging.rs"]
+mod logging;
 
 pub fn button<T>(
     content: impl View<T>,
@@ -14,8 +16,9 @@ pub fn button<T>(
         .on_click(click_cb)
 }
 
-fn main() -> Result<()> {
-    let _ = setup_logging(tracing::Level::DEBUG)?;
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = crate::logging::setup_logging(tracing::Level::DEBUG)?;
 
     App::new(0, |count| {
         v_stack((
@@ -28,5 +31,7 @@ fn main() -> Result<()> {
             }),
         ))
     })
+    .await
     .run()
+    .await
 }

--- a/examples/button.rs
+++ b/examples/button.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use ratatui::style::{Color, Style};
+use trui::logging::setup_logging;
 use trui::*;
 
 pub fn button<T>(
@@ -14,6 +15,8 @@ pub fn button<T>(
 }
 
 fn main() -> Result<()> {
+    let _ = setup_logging(tracing::Level::DEBUG)?;
+
     App::new(0, |count| {
         v_stack((
             button(

--- a/examples/local_state.rs
+++ b/examples/local_state.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use trui::logging::setup_logging;
 use trui::*;
 
 struct AppState {
@@ -46,6 +47,8 @@ fn button_use_state<T, V: View<(Handle<T>, i32)>>(
 }
 
 fn main() -> Result<()> {
+    let _ = setup_logging(tracing::Level::DEBUG)?;
+
     App::new(
         AppState {
             count: 0,

--- a/examples/local_state.rs
+++ b/examples/local_state.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
-use trui::logging::setup_logging;
 use trui::*;
+
+#[path = "./shared/logging.rs"]
+mod logging;
 
 struct AppState {
     count: i32,
@@ -46,8 +48,9 @@ fn button_use_state<T, V: View<(Handle<T>, i32)>>(
     )
 }
 
-fn main() -> Result<()> {
-    let _ = setup_logging(tracing::Level::DEBUG)?;
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = crate::logging::setup_logging(tracing::Level::DEBUG)?;
 
     App::new(
         AppState {
@@ -72,5 +75,7 @@ fn main() -> Result<()> {
             ))
         },
     )
+    .await
     .run()
+    .await
 }

--- a/examples/rainbow_blocks.rs
+++ b/examples/rainbow_blocks.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use ratatui::style::Color;
+use trui::logging::setup_logging;
 use trui::{
     memoize, v_stack, AnyView, App, BorderKind, Borders, EventHandler, IntoBoxedView, Styleable,
     View, ViewExt,
@@ -64,6 +65,8 @@ impl AppState {
 }
 
 fn main() -> Result<()> {
+    let _ = setup_logging(tracing::Level::DEBUG)?;
+
     App::new(
         AppState {
             count: 10,

--- a/examples/rainbow_blocks.rs
+++ b/examples/rainbow_blocks.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use ratatui::style::Color;
-use trui::logging::setup_logging;
 use trui::{
     memoize, v_stack, AnyView, App, BorderKind, Borders, EventHandler, IntoBoxedView, Styleable,
     View, ViewExt,
 };
+
+#[path = "./shared/logging.rs"]
+mod logging;
 
 // TODO this basic logic (hover, styling etc.) should probably be its own widget (state)...
 pub fn button<T>(
@@ -64,8 +66,9 @@ impl AppState {
     }
 }
 
-fn main() -> Result<()> {
-    let _ = setup_logging(tracing::Level::DEBUG)?;
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = crate::logging::setup_logging(tracing::Level::DEBUG)?;
 
     App::new(
         AppState {
@@ -135,5 +138,7 @@ fn main() -> Result<()> {
             ))
         },
     )
+    .await
     .run()
+    .await
 }

--- a/examples/shared/logging.rs
+++ b/examples/shared/logging.rs
@@ -7,6 +7,7 @@ pub fn setup_logging(
 ) -> Result<tracing_appender::non_blocking::WorkerGuard> {
     let proj_dirs = ProjectDirs::from("", "", "trui").expect("Opening cache directory");
     let cache_dir = proj_dirs.cache_dir();
+
     let tracing_file_appender = tracing_appender::rolling::never(cache_dir, "trui.log");
     let (tracing_file_writer, guard) = tracing_appender::non_blocking(tracing_file_appender);
 
@@ -16,5 +17,6 @@ pub fn setup_logging(
     );
     tracing::subscriber::set_global_default(subscriber)?;
 
+    tracing::debug!("tracing initialized");
     Ok(guard)
 }

--- a/examples/wrapped_text.rs
+++ b/examples/wrapped_text.rs
@@ -1,18 +1,21 @@
 use anyhow::Result;
-use trui::logging::setup_logging;
 // use ratatui::style::Color;
 // use trui::*;
 
+#[path = "./shared/logging.rs"]
+mod logging;
+
 // TODO this currently doesn't work anymore
-fn main() -> Result<()> {
-    let _ = setup_logging(tracing::Level::DEBUG)?;
+#[tokio::main]
+async fn main() -> Result<()> {
+    let _guard = crate::logging::setup_logging(tracing::Level::DEBUG)?;
     // App::new((), |()| {
     //     h_stack((
     //         block(("Different ".fg(Color::Red), "Colors that are wrapped: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.".fg(Color::Blue)).wrapped()),
     //         // TODO proper wrapping with new lines etc.
     //         block("This should be wrapped very soon:\n\n Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.".wrapped()),
     //     ))
-    // })
-    // .run()
+    // }).await
+    // .run().await;
     Ok(())
 }

--- a/examples/wrapped_text.rs
+++ b/examples/wrapped_text.rs
@@ -1,9 +1,11 @@
 use anyhow::Result;
+use trui::logging::setup_logging;
 // use ratatui::style::Color;
 // use trui::*;
 
 // TODO this currently doesn't work anymore
 fn main() -> Result<()> {
+    let _ = setup_logging(tracing::Level::DEBUG)?;
     // App::new((), |()| {
     //     h_stack((
     //         block(("Different ".fg(Color::Red), "Colors that are wrapped: Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.".fg(Color::Blue)).wrapped()),

--- a/src/app.rs
+++ b/src/app.rs
@@ -107,18 +107,18 @@ enum UiState {
 }
 
 impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
-    pub fn new(data: T, app_logic: impl FnMut(&mut T) -> V + Send + 'static) -> Self {
-        App::new_with_config(AppConfig::default(), data, app_logic)
+    pub async fn new(data: T, app_logic: impl FnMut(&mut T) -> V + Send + 'static) -> Self {
+        App::new_with_config(AppConfig::default(), data, app_logic).await
     }
 
-    pub fn new_with_config(
+    pub async fn new_with_config(
         config: AppConfig,
         data: T,
         app_logic: impl FnMut(&mut T) -> V + Send + 'static,
     ) -> Self {
-        // Create a new tokio runtime. Doing it here is hacky, we should allow
+        // TODO(zoechi): Create a new tokio runtime. Doing it here is hacky, we should allow
         // the client to do it.
-        let rt = Arc::new(tokio::runtime::Runtime::new().unwrap());
+        // let rt = Arc::new(tokio::runtime::Runtime::new().unwrap());
 
         // Note: there is danger of deadlock if exceeded; think this through.
         const CHANNEL_SIZE: usize = 1000;
@@ -135,9 +135,9 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
         // context. Consider crossbeam and flume channels as alternatives.
         let message_tx_clone = message_tx.clone();
         let (wake_tx, wake_rx) = std::sync::mpsc::sync_channel(10);
-        std::thread::spawn(move || {
+        config.runtime_handle().spawn(async move {
             while let Ok(id_path) = wake_rx.recv() {
-                let _ = message_tx_clone.blocking_send(AppMessage::Wake(id_path));
+                let _ = message_tx_clone.send(AppMessage::Wake(id_path)).await;
             }
         });
 
@@ -147,7 +147,7 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
         let event_tx_clone = event_tx.clone();
 
         // Until we have a solid way to sync with the screen refresh rate, do an update every 1/60 secs when it is requested
-        rt.spawn(async move {
+        config.runtime_handle().spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs_f64(1.0 / 60.0));
             interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -162,7 +162,7 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
 
         // spawn io event proxy task
         let event_tx_clone = event_tx.clone();
-        std::thread::spawn(move || {
+        config.runtime_handle().spawn(async move {
             loop {
                 if let Ok(true) = poll(Duration::from_millis(100)) {
                     let event = match read() {
@@ -181,7 +181,7 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
 
                     let quit = matches!(event, Event::Quit);
 
-                    let _ = event_tx_clone.blocking_send(event);
+                    let _ = event_tx_clone.send(event).await;
 
                     if quit {
                         break;
@@ -191,11 +191,11 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
         });
 
         // Send this event here, so that the app renders directly when it is run.
-        let _ = event_tx.blocking_send(Event::Start);
+        let _ = event_tx.send(Event::Start).await;
 
         let event_tx_clone = event_tx.clone();
         // spawn app task
-        rt.spawn(async move {
+        config.runtime_handle().spawn(async move {
             let mut app_task = AppTask {
                 req_chan: message_rx,
                 response_chan: response_tx,
@@ -211,7 +211,7 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
             app_task.run().await;
         });
 
-        let cx = Cx::new(&wake_tx, rt);
+        let cx = Cx::new(&wake_tx, config.runtime_handle());
 
         App {
             config,
@@ -234,19 +234,19 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
         }
     }
 
-    fn send_events(&mut self) {
+    async fn send_events(&mut self) {
         if !self.events.is_empty() {
             let events = std::mem::take(&mut self.events);
-            let _ = self.req_chan.blocking_send(AppMessage::Events(events));
+            let _ = self.req_chan.send(AppMessage::Events(events)).await;
         }
     }
 
     /// Run the app logic and update the widget tree.
     /// Returns whether a rerender should be scheduled
     #[tracing::instrument(skip(self))]
-    fn render(&mut self, time_since_last_render: Duration) -> Result<bool> {
-        if self.build_widget_tree(false) {
-            self.build_widget_tree(true);
+    async fn render(&mut self, time_since_last_render: Duration) -> Result<bool> {
+        if self.build_widget_tree(false).await {
+            self.build_widget_tree(true).await;
         }
         let root_pod = self.root_pod.as_mut().unwrap();
         let cx_state = &mut CxState::new(&mut self.events, time_since_last_render);
@@ -340,10 +340,10 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
     /// Run one pass of app logic.
     ///
     /// Return value is whether there are any pending async futures.
-    fn build_widget_tree(&mut self, delay: bool) -> bool {
+    async fn build_widget_tree(&mut self, delay: bool) -> bool {
         self.cx.pending_async.clear();
-        let _ = self.req_chan.blocking_send(AppMessage::Render(delay));
-        if let Some(response) = self.render_response_chan.blocking_recv() {
+        let _ = self.req_chan.send(AppMessage::Render(delay)).await;
+        if let Some(response) = self.render_response_chan.recv().await {
             let state = if let Some(widget) = self.root_pod.as_mut() {
                 let mut state = response.state.unwrap();
                 let changes = response.view.rebuild(
@@ -368,16 +368,14 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
             };
             let pending = std::mem::take(&mut self.cx.pending_async);
             let has_pending = !pending.is_empty();
-            let _ = self
-                .return_chan
-                .blocking_send((response.view, state, pending));
+            let _ = self.return_chan.send((response.view, state, pending)).await;
             has_pending
         } else {
             false
         }
     }
 
-    pub fn run(mut self) -> Result<()> {
+    pub async fn run(mut self) -> Result<()> {
         #[cfg(not(any(test, doctest, feature = "doctests")))]
         self.init_terminal()?;
 
@@ -386,7 +384,7 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
         let main_loop_tracing_span = tracing::debug_span!("main loop");
         let mut time_of_last_render = Instant::now();
         let mut time_since_last_render_request = Duration::ZERO;
-        while let Some(event) = self.event_chan.blocking_recv() {
+        while let Some(event) = self.event_chan.recv().await {
             let mut events = vec![event];
             // batch events
             while let Ok(event) = self.event_chan.try_recv() {
@@ -416,9 +414,9 @@ impl<T: Send + 'static, V: View<T> + 'static> App<T, V> {
                     root_pod.event(&mut cx, &event);
                 }
             }
-            self.send_events();
+            self.send_events().await;
 
-            let rerender_requested = self.render(time_since_last_render_request)?;
+            let rerender_requested = self.render(time_since_last_render_request).await?;
             // TODO this is a workaround (I consider this at least as that) for getting animations right
             // There's likely a cleaner solution
             if rerender_requested {

--- a/src/app_config.rs
+++ b/src/app_config.rs
@@ -1,0 +1,58 @@
+#[cfg(not(any(test, doctest, feature = "doctests")))]
+use std::io::stdout;
+
+#[cfg(not(any(test, doctest, feature = "doctests")))]
+use ratatui::backend::CrosstermBackend;
+
+#[cfg(any(test, doctest, feature = "doctests"))]
+use ratatui::backend::TestBackend;
+
+use ratatui::Terminal;
+
+#[cfg(not(any(test, doctest, feature = "doctests")))]
+use std::io::Stdout;
+
+pub struct AppConfig {
+    #[cfg(any(test, doctest, feature = "doctests"))]
+    pub(crate) terminal: Terminal<TestBackend>,
+
+    #[cfg(not(any(test, doctest, feature = "doctests")))]
+    pub(crate) terminal: Terminal<CrosstermBackend<Stdout>>,
+}
+
+impl AppConfig {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[cfg(not(any(test, doctest, feature = "doctests")))]
+    pub fn with_backend(mut self, backend: CrosstermBackend<Stdout>) -> Self {
+        self.terminal = Terminal::new(backend).unwrap();
+        self
+    }
+
+    #[cfg(any(test, doctest, feature = "doctests"))]
+    pub fn with_backend(mut self, backend: TestBackend) -> Self {
+        self.terminal = Terminal::new(backend).unwrap();
+        self
+    }
+
+    #[cfg(any(test, doctest, feature = "doctests"))]
+    pub(crate) fn terminal_mut(&mut self) -> &mut Terminal<TestBackend> {
+        &mut self.terminal
+    }
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        #[cfg(not(any(test, doctest, feature = "doctests")))]
+        let backend = CrosstermBackend::new(stdout()); // TODO handle errors...
+
+        #[cfg(any(test, doctest, feature = "doctests"))]
+        let backend = TestBackend::new(80, 40);
+
+        let terminal = Terminal::new(backend).unwrap();
+
+        Self { terminal }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 mod app;
+mod app_config;
 pub mod geometry;
 pub mod logging;
 mod view;
@@ -6,6 +7,7 @@ mod widget;
 
 // wildcards at least temporarily for convenience...
 pub use app::App;
+pub use app_config::AppConfig;
 pub use ratatui::style::{Color, Modifier, Style};
 pub use view::*;
 pub use widget::CatchMouseButton;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 mod app;
 pub mod geometry;
+pub mod logging;
 mod view;
 mod widget;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 mod app;
 mod app_config;
 pub mod geometry;
-pub mod logging;
 mod view;
 mod widget;
 

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use directories::ProjectDirs;
+use tracing_subscriber::{fmt::writer::MakeWriterExt, layer::SubscriberExt, Registry};
+
+pub fn setup_logging(
+    log_level: tracing::Level,
+) -> Result<tracing_appender::non_blocking::WorkerGuard> {
+    let proj_dirs = ProjectDirs::from("", "", "trui").expect("Opening cache directory");
+    let cache_dir = proj_dirs.cache_dir();
+    let tracing_file_appender = tracing_appender::rolling::never(cache_dir, "trui.log");
+    let (tracing_file_writer, guard) = tracing_appender::non_blocking(tracing_file_appender);
+
+    let subscriber = Registry::default().with(
+        tracing_subscriber::fmt::Layer::default()
+            .with_writer(tracing_file_writer.with_max_level(log_level)),
+    );
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    Ok(guard)
+}

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -41,7 +41,7 @@ pub fn render_view<T: Send + 'static>(
             .backend_mut()
             .resize(buffer_size.width, buffer_size.height);
 
-        app.run_without_logging().unwrap()
+        app.run().unwrap()
     });
 
     let event_tx = event_rx.blocking_recv().unwrap();

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -37,7 +37,8 @@ pub fn render_view<T: Send + 'static>(
         });
         event_tx_clone.blocking_send(app.event_tx()).unwrap();
 
-        app.terminal_mut()
+        app.config
+            .terminal_mut()
             .backend_mut()
             .resize(buffer_size.width, buffer_size.height);
 

--- a/src/test_helper.rs
+++ b/src/test_helper.rs
@@ -1,13 +1,17 @@
 use std::env;
+use std::error::Error;
+use std::fs::File;
 use std::io::stdout;
 use std::marker::PhantomData;
 use std::sync::Arc;
 
+use directories::ProjectDirs;
 use ratatui::layout::Size;
 use ratatui::prelude::*;
 
-use ratatui::{Terminal, TerminalOptions, Viewport};
 use tokio::sync::mpsc;
+use tracing::subscriber::DefaultGuard;
+use tracing_subscriber::{fmt::writer::MakeWriterExt, layer::SubscriberExt};
 use xilem_core::MessageResult;
 
 use crate::widget::{BoxConstraints, ChangeFlags, Event};
@@ -20,37 +24,34 @@ use crate::{App, Cx, View, ViewMarker};
 /// * `sut` - A closure that returns the widget to test when called.
 ///   This expects a function so it can create it inside the thread of the [`App`].
 /// * `state` - Is the state for the [`App`]
-pub fn render_view<T: Send + 'static>(
+///
+/// Because [`App`](crate::App) is not [`Send`](Send), this function needs to be
+/// executed inside a [`LocalSet`](tokio::task::LocalSet)
+pub async fn render_view<T: Send + 'static>(
     buffer_size: Size,
     sut: Arc<impl View<T> + 'static>,
     state: T,
 ) -> Buffer {
     const CHANNEL_SIZE: usize = 3;
     let (message_tx, mut message_rx) = mpsc::channel::<Buffer>(CHANNEL_SIZE);
-    let (event_tx, mut event_rx) = mpsc::channel(CHANNEL_SIZE);
+    let mut app = App::new(state, move |_state| {
+        debug_view(sut.clone(), message_tx.clone())
+    })
+    .await;
 
-    let event_tx_clone = event_tx.clone();
+    let event_tx = app.event_tx();
+    app.config
+        .terminal_mut()
+        .backend_mut()
+        .resize(buffer_size.width, buffer_size.height);
 
-    let join_handle = std::thread::spawn(move || {
-        let mut app = App::new(state, move |_state| {
-            debug_view(sut.clone(), message_tx.clone())
-        });
-        event_tx_clone.blocking_send(app.event_tx()).unwrap();
-
-        app.config
-            .terminal_mut()
-            .backend_mut()
-            .resize(buffer_size.width, buffer_size.height);
-
-        app.run().unwrap()
+    tokio::task::spawn_local(async {
+        app.run().await.unwrap();
     });
 
-    let event_tx = event_rx.blocking_recv().unwrap();
+    let buffer = message_rx.recv().await;
 
-    let buffer = message_rx.blocking_recv();
-    let send_quit_ack = event_tx.blocking_send(Event::Quit);
-
-    join_handle.join().unwrap();
+    let send_quit_ack = event_tx.send(Event::Quit).await;
 
     // delay unwrapping until after join_handle.join() to not mask errors from the spawned thread
     send_quit_ack.unwrap();
@@ -144,7 +145,10 @@ impl Widget for DebugWidget {
         cx.terminal.flush().unwrap();
 
         let buffer = cx.terminal.backend().buffer().to_owned();
-        self.debug_chan_tx.blocking_send(buffer).unwrap();
+        let chan_tx = self.debug_chan_tx.clone();
+        tokio::task::spawn_local(async move {
+            chan_tx.send(buffer).await.unwrap();
+        });
     }
 
     fn layout(&mut self, cx: &mut crate::widget::LayoutCx, bc: &BoxConstraints) -> kurbo::Size {
@@ -187,4 +191,22 @@ pub fn print_buffer(buffer: &Buffer) -> std::io::Result<()> {
         crossterm::queue!(stdout(), crossterm::cursor::MoveTo(0, buffer.area.height))?;
     };
     Ok(())
+}
+
+/// Initialize tracing individually for each thread so that concurrently running
+/// tests do not cause conflicts
+pub fn init_tracing(test_name: &str) -> Result<DefaultGuard, Box<dyn Error>> {
+    let proj_dirs = ProjectDirs::from("", "", "trui").expect("Opening cache directory");
+    let cache_dir = proj_dirs.cache_dir();
+
+    let file = File::create(cache_dir.join(format!("{test_name}.log")))?;
+
+    let subscriber = tracing_subscriber::registry().with(
+        tracing_subscriber::fmt::Layer::default()
+            .with_writer(Arc::new(file).with_max_level(tracing::Level::DEBUG)),
+    );
+
+    let guard = tracing::subscriber::set_default(subscriber);
+
+    Ok(guard)
 }

--- a/src/view/border.rs
+++ b/src/view/border.rs
@@ -243,32 +243,51 @@ mod tests {
 
     struct AppState;
 
-    #[test]
-    fn simple_border_test() {
-        let sut = Arc::new("some text".fg(Color::Cyan).border(()));
-        let buffer = render_view(
-            Size {
-                width: 15,
-                height: 5,
-            },
-            sut,
-            AppState,
-        );
+    #[tokio::test]
+    async fn simple_border_test() {
+        let _guard = crate::test_helper::init_tracing("simple_border_test").unwrap();
 
-        insta::assert_debug_snapshot!(buffer);
+        // console_subscriber::init();
+        let local_set = tokio::task::LocalSet::new();
+        local_set
+            .run_until(async {
+                let sut = Arc::new("some text".fg(Color::Cyan).border(()));
+                let buffer = render_view(
+                    Size {
+                        width: 15,
+                        height: 5,
+                    },
+                    sut,
+                    AppState,
+                )
+                .await;
+
+                insta::assert_debug_snapshot!(buffer);
+            })
+            .await
     }
 
-    #[test]
-    fn too_small_viewport() {
-        let sut = Arc::new("some text".fg(Color::Cyan).border(BorderKind::Straight));
-        let buffer = render_view(
-            Size {
-                width: 7,
-                height: 5,
-            },
-            sut,
-            AppState,
-        );
-        insta::assert_debug_snapshot!(buffer);
+    #[tokio::test]
+    async fn too_small_viewport() {
+        let _guard = crate::test_helper::init_tracing("too_small_viewport").unwrap();
+
+        let local_set = tokio::task::LocalSet::new();
+        local_set
+            .run_until(async {
+                tracing::debug!("too_small_viewport test");
+
+                let sut = Arc::new("some text".fg(Color::Cyan).border(BorderKind::Straight));
+                let buffer = render_view(
+                    Size {
+                        width: 7,
+                        height: 5,
+                    },
+                    sut,
+                    AppState,
+                )
+                .await;
+                insta::assert_debug_snapshot!(buffer);
+            })
+            .await
     }
 }

--- a/src/view/core.rs
+++ b/src/view/core.rs
@@ -3,10 +3,8 @@ use std::{
     sync::{mpsc::SyncSender, Arc},
 };
 
-use futures_task::{ArcWake, Waker};
-use tokio::runtime::Runtime;
-
 use crate::widget::{AnyWidget, ChangeFlags, Pod, Widget};
+use futures_task::{ArcWake, Waker};
 use xilem_core::{Id, IdPath};
 
 xilem_core::generate_view_trait!(View, Widget, Cx, ChangeFlags; (ViewMarker + Send + Sync), (Send));
@@ -20,12 +18,12 @@ xilem_core::generate_rc_view!(std::sync::Arc, View, ViewMarker, Cx, ChangeFlags,
 pub struct Cx {
     id_path: IdPath,
     req_chan: SyncSender<IdPath>,
-    pub rt: Arc<Runtime>,
+    pub rt: tokio::runtime::Handle,
     pub(crate) pending_async: HashSet<Id>,
 }
 
 impl Cx {
-    pub(crate) fn new(req_chan: &SyncSender<IdPath>, rt: Arc<Runtime>) -> Self {
+    pub(crate) fn new(req_chan: &SyncSender<IdPath>, rt: tokio::runtime::Handle) -> Self {
         Cx {
             id_path: Vec::new(),
             req_chan: req_chan.clone(),


### PR DESCRIPTION
I initially just wanted to clean up `app.rs` a bit, 
like the TODO about configurable runtime, the many conditionals for test code and also the initialization of tracing that shouldn't be hardcoded in a library.
Then I tried to run with just the `#[tokio::main]` attribute to verify my changes. I run into many blocking send's and recv's.  

I thought that initializing a async runtime using `#[tokio::main]` would be the main use case. So I tried to make it work. That led to changing everything to async to avoid the blocking.
I also could have introduced another thread somewhere to make the original code work again.

I'm not sure if I'm missing something, but to me it looks like there is not really any CPU bound workload, but almost only I/O processing, so fully utilizing async would make sense to me. I think if there is some CPU-heavy work to do, it would be ideal to just offload these parts to additional threads.  
(Re)Creating the views and diffing the trees is some actual CPU work, but my assumption is, that this is not enough to saturate a thread, and if, this specifically should be offloaded to additional threads.

The PR currently is just a basis for discussion and feedback and needs a bit more work.
Especially the async runtime in `AppConfig` and the `Handle`'s derived from it seem redundant to me. I think just using the runtime from the context should be enough (without any configuration option).

If this goes against your plans or goals, I'm happy to learn and to choose a different approach.

(modified to fix typo)